### PR TITLE
Nathan/oauth flow fixes

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,6 +13,7 @@ import {
   OAUTH_TOKEN_PATH,
   authBaseUrl,
   oauthClientId,
+  subtextOauthResource,
   type Region,
   type WizardOptions,
 } from './config.js';
@@ -33,7 +34,9 @@ export interface SubtextAuth {
  *   1. Dynamically register a public client (RFC 7591) unless a
  *      pre-registered client id is configured.
  *   2. Authorization-code + PKCE (S256), loopback redirect (RFC 8252) —
- *      we listen on an ephemeral 127.0.0.1 port for the callback.
+ *      we listen on an ephemeral 127.0.0.1 port for the callback. The
+ *      request carries the RFC 8707 resource indicator for the Subtext MCP
+ *      resource, which selects Subtext branding on the OAuth pages.
  *   3. Exchange the code at /oauth/token (public client, no secret).
  *
  * The access token is `<realm>.oauth!<JWT>`; the JWT payload carries
@@ -74,6 +77,7 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
   }
 
   const authBase = authBaseUrl(options.region);
+  const resource = subtextOauthResource(options.region);
   const clientId = oauthClientId(options.region) ?? (await registerClient(authBase));
 
   // Loopback server for the OAuth redirect.
@@ -91,6 +95,7 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
   authorizeUrl.searchParams.set('state', state);
   authorizeUrl.searchParams.set('code_challenge', challenge);
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+  authorizeUrl.searchParams.set('resource', resource);
   if (OAUTH_SCOPES) authorizeUrl.searchParams.set('scope', OAUTH_SCOPES);
 
   p.log.step('Log in to Subtext to link this install to your org.');
@@ -127,6 +132,7 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
     clientId,
     redirectUri,
     verifier,
+    resource,
   }).catch((error) => {
     spinner.stop('Login failed.', 1);
     throw error;
@@ -276,7 +282,7 @@ interface TokenResponse {
 
 async function exchangeCode(
   authBase: string,
-  args: { code: string; clientId: string; redirectUri: string; verifier: string },
+  args: { code: string; clientId: string; redirectUri: string; verifier: string; resource: string },
 ): Promise<TokenResponse> {
   const res = await fetch(`${authBase}${OAUTH_TOKEN_PATH}`, {
     method: 'POST',
@@ -287,6 +293,10 @@ async function exchangeCode(
       redirect_uri: args.redirectUri,
       client_id: args.clientId,
       code_verifier: args.verifier,
+      // RFC 8707: the token request repeats the resource indicator from the
+      // authorization request. Heimdall ignores it today (no audience
+      // restriction yet) but MCP-spec clients send it on both requests.
+      resource: args.resource,
     }),
     signal: AbortSignal.timeout(15_000),
   });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,12 +6,13 @@ import open from 'open';
 import pc from 'picocolors';
 import {
   AUTH_CALLBACK_TIMEOUT_MS,
+  AUTH_PROMPT_AFTER_MS,
   OAUTH_AUTHORIZE_PATH,
-  OAUTH_CLIENT_ID,
   OAUTH_REGISTER_PATH,
   OAUTH_SCOPES,
   OAUTH_TOKEN_PATH,
   authBaseUrl,
+  oauthClientId,
   type Region,
   type WizardOptions,
 } from './config.js';
@@ -73,7 +74,7 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
   }
 
   const authBase = authBaseUrl(options.region);
-  const clientId = OAUTH_CLIENT_ID ?? (await registerClient(authBase));
+  const clientId = oauthClientId(options.region) ?? (await registerClient(authBase));
 
   // Loopback server for the OAuth redirect.
   const { server, port, callbackPromise } = await startCallbackServer();
@@ -106,15 +107,7 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
 
   let code: string;
   try {
-    const callback = await Promise.race([
-      callbackPromise,
-      new Promise<never>((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Timed out waiting for browser login. Re-run the installer to try again.')),
-          AUTH_CALLBACK_TIMEOUT_MS,
-        ).unref(),
-      ),
-    ]);
+    const callback = await waitForCallback(callbackPromise, spinner);
     if (callback.state !== state) {
       throw new Error('OAuth state mismatch — aborting login for safety. Re-run the installer.');
     }
@@ -156,6 +149,54 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
     userEmail: claims.userEmail,
     region: claims.region ?? options.region,
   };
+}
+
+/**
+ * Waits for the OAuth loopback callback. After AUTH_PROMPT_AFTER_MS of
+ * silence, asks whether to keep waiting instead of giving up — a first-time
+ * signup detours through email verification and password setup, which takes
+ * far longer than any reasonable silent timeout, and the flow can only
+ * complete if this process keeps listening. Gives up for good once
+ * AUTH_CALLBACK_TIMEOUT_MS elapses.
+ */
+async function waitForCallback(
+  callbackPromise: Promise<CallbackResult>,
+  spinner: ReturnType<typeof p.spinner>,
+): Promise<CallbackResult> {
+  const deadline = Date.now() + AUTH_CALLBACK_TIMEOUT_MS;
+  for (;;) {
+    const waitMs = Math.min(AUTH_PROMPT_AFTER_MS, deadline - Date.now());
+    if (waitMs <= 0) {
+      throw new Error('Timed out waiting for browser login. Re-run the installer to try again.');
+    }
+    const result = await Promise.race([
+      callbackPromise,
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), waitMs).unref()),
+    ]);
+    if (result !== 'timeout') {
+      return result;
+    }
+
+    spinner.stop('Still waiting for browser login.');
+    const keepWaiting = await Promise.race([
+      callbackPromise,
+      p.confirm({
+        message:
+          'Keep waiting? (If you just created an account, finish the email verification ' +
+          'and password steps in your browser — this window will pick the login back up.)',
+      }),
+    ]);
+    if (typeof keepWaiting === 'object') {
+      // The callback arrived while the prompt was up.
+      spinner.start('Finishing login…');
+      return keepWaiting;
+    }
+    if (p.isCancel(keepWaiting) || !keepWaiting) {
+      spinner.start('Waiting for you to finish logging in…');
+      throw new Error('Login canceled. Re-run the installer to try again.');
+    }
+    spinner.start('Waiting for you to finish logging in…');
+  }
 }
 
 /** RFC 7591 dynamic client registration — same call MCP clients make. */
@@ -205,7 +246,7 @@ async function startCallbackServer(): Promise<{
     res.writeHead(200, { 'Content-Type': 'text/html' });
     res.end(
       error
-        ? '<html><body><h2>Login failed</h2><p>You can close this tab and return to the terminal.</p></body></html>'
+        ? '<html><body><h2>Login didn&rsquo;t complete</h2><p>Close this tab, return to your terminal, and re-run <code>npx @subtext/install</code> to try again.</p></body></html>'
         : '<html><body><h2>Logged in to Subtext</h2><p>You can close this tab and return to the terminal.</p></body></html>',
     );
     resolveCallback({

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,11 +49,25 @@ export const OAUTH_TOKEN_PATH = '/oauth/token';
 export const OAUTH_REGISTER_PATH = '/oauth/register';
 
 /**
- * OAuth client id for the wizard. When unset, the wizard dynamically
- * registers itself (RFC 7591) on each run — this works today but a
- * pre-registered first-party client id should replace it (see plan doc).
+ * Pre-registered Subtext OAuth client ids, per realm. Populate once the
+ * Subtext client is registered in each realm's heimdall (required for the
+ * Subtext-branded OAuth pages — heimdall keys branding off a stable
+ * client_id; see mn PR cowpaths/mn#106970). Until then the wizard falls back
+ * to RFC 7591 dynamic registration on each run.
  */
-export const OAUTH_CLIENT_ID = process.env.SUBTEXT_OAUTH_CLIENT_ID;
+const PREREGISTERED_OAUTH_CLIENT_IDS: Partial<Record<Region, string>> = {
+  // us: pending pre-registration
+  // eu: pending pre-registration
+};
+
+/**
+ * OAuth client id for the wizard. Resolution order: SUBTEXT_OAUTH_CLIENT_ID
+ * env override → pre-registered per-realm client id → undefined, in which
+ * case the wizard dynamically registers itself (RFC 7591) on each run.
+ */
+export function oauthClientId(region: Region): string | undefined {
+  return process.env.SUBTEXT_OAUTH_CLIENT_ID ?? PREREGISTERED_OAUTH_CLIENT_IDS[region];
+}
 
 /**
  * Scopes requested during authorization. The install itself needs none of
@@ -79,7 +93,19 @@ export function telemetryUrl(region: Region): string {
   return `${apiBaseUrl(region)}${TELEMETRY_PATH}`;
 }
 
-export const AUTH_CALLBACK_TIMEOUT_MS = 5 * 60_000;
+/**
+ * How long the browser-login wait stays silent before asking the user whether
+ * to keep waiting. Kept short enough that a stuck login surfaces quickly.
+ */
+export const AUTH_PROMPT_AFTER_MS = 5 * 60_000;
+
+/**
+ * Hard cap on the whole browser login. Deliberately long: a first-time signup
+ * detours through email verification and password setup, and the loopback
+ * server must still be listening when the OAuth flow restarts and delivers
+ * the code afterwards.
+ */
+export const AUTH_CALLBACK_TIMEOUT_MS = 60 * 60_000;
 
 export interface WizardOptions {
   /** Directory of the app being instrumented. Defaults to cwd. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,10 +50,12 @@ export const OAUTH_REGISTER_PATH = '/oauth/register';
 
 /**
  * Pre-registered Subtext OAuth client ids, per realm. Populate once the
- * Subtext client is registered in each realm's heimdall (required for the
- * Subtext-branded OAuth pages — heimdall keys branding off a stable
- * client_id; see mn PR cowpaths/mn#106970). Until then the wizard falls back
- * to RFC 7591 dynamic registration on each run.
+ * Subtext client is registered in each realm's heimdall — a stable
+ * first-party client avoids polluting the client table and hitting the
+ * registration rate limit with a fresh RFC 7591 registration on every run.
+ * Until then the wizard falls back to dynamic registration. (Branding does
+ * not depend on this: heimdall keys the Subtext-branded OAuth pages off the
+ * RFC 8707 resource indicator — see subtextOauthResource below.)
  */
 const PREREGISTERED_OAUTH_CLIENT_IDS: Partial<Record<Region, string>> = {
   // us: pending pre-registration
@@ -76,6 +78,17 @@ export function oauthClientId(region: Region): string | undefined {
  * tracked in the plan doc.
  */
 export const OAUTH_SCOPES = process.env.SUBTEXT_OAUTH_SCOPES ?? 'sessions:read';
+
+/**
+ * RFC 8707 resource indicator sent on the authorization and token requests,
+ * identifying the Subtext MCP resource. Heimdall keys the Subtext branding
+ * of its OAuth pages (login, consent) off this value's /mcp/subtext path —
+ * see mn PR cowpaths/mn#106970 — and MCP clients send the same indicator,
+ * so the wizard's login gets the same branded flow they do.
+ */
+export function subtextOauthResource(region: Region): string {
+  return `${apiBaseUrl(region)}/mcp/subtext`;
+}
 
 /** Public, unauthenticated snippet endpoint (snippet service). `type=CORE`
  * returns the full inline snippet body for a <script> tag. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,9 +82,12 @@ export const OAUTH_SCOPES = process.env.SUBTEXT_OAUTH_SCOPES ?? 'sessions:read';
 /**
  * RFC 8707 resource indicator sent on the authorization and token requests,
  * identifying the Subtext MCP resource. Heimdall keys the Subtext branding
- * of its OAuth pages (login, consent) off this value's /mcp/subtext path —
- * see mn PR cowpaths/mn#106970 — and MCP clients send the same indicator,
- * so the wizard's login gets the same branded flow they do.
+ * of its OAuth pages off this value's /mcp/subtext path when it is the sole
+ * resource named (isSubtextResource): the consent page in cowpaths/mn#106970
+ * and the login page the wizard's browser flow hits first in cowpaths/mn#106971.
+ * MCP clients send the same indicator, so the wizard's login gets the same
+ * branded flow they do. The string must match gangplank's advertised RFC 9728
+ * metadata (https://api.<Domain>/mcp/subtext) byte-for-byte.
  */
 export function subtextOauthResource(region: Region): string {
   return `${apiBaseUrl(region)}/mcp/subtext`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,14 +29,6 @@ export function appBaseUrl(region: Region): string {
   return region === 'eu' ? 'https://app.eu1.fullstory.com' : 'https://app.fullstory.com';
 }
 
-/**
- * TEMPORARY: the Subtext-themed account creation page (webber
- * `/subtext/signup`). Used to hand new users an account before the OAuth
- * login below — remove once OAuth-native signup lands and drop the offer in
- * run.ts with it.
- */
-export const SUBTEXT_SIGNUP_PATH = '/subtext/signup';
-
 /** Capture hosts baked into the snippet, realm-aware. */
 export function captureHosts(region: Region): { host: string; script: string } {
   return region === 'eu'

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,11 +1,10 @@
 import * as p from '@clack/prompts';
 import clipboard from 'clipboardy';
-import open from 'open';
 import pc from 'picocolors';
 import { authenticate } from './auth.js';
 import { chooseAgent, detectAgents, MANUAL_CHOICE } from './agents/index.js';
 import type { WizardOptions } from './config.js';
-import { WIZARD_VERSION, appBaseUrl, SUBTEXT_SIGNUP_PATH, telemetryUrl } from './config.js';
+import { WIZARD_VERSION, telemetryUrl } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
 import { guidePluginSetup } from './plugin.js';
@@ -31,37 +30,6 @@ export async function runWizard(options: WizardOptions): Promise<number> {
   telemetry.note('wizard_started', { mock: options.mock, dir_provided: options.dir !== process.cwd() });
 
   try {
-    // 0. TEMPORARY (until OAuth-native signup lands): offer account creation.
-    //    New users have no org yet, so the OAuth login below would dead-end —
-    //    send them to the Subtext signup page first, then continue into login
-    //    once they confirm they're done. A pre-supplied token already implies
-    //    an account, so skip the offer entirely there. Remove this whole block
-    //    (and SUBTEXT_SIGNUP_PATH) when signup is part of the OAuth flow.
-    if (!options.apiKey) {
-      const needsAccount = await p.confirm({
-        message: 'Do you need to create a new Subtext account?',
-        initialValue: true,
-      });
-      if (p.isCancel(needsAccount)) throw new CancelledError();
-      if (needsAccount) {
-        const signupUrl = `${appBaseUrl(options.region)}${SUBTEXT_SIGNUP_PATH}`;
-        p.log.step('Opening the Subtext account creation page in your browser.');
-        p.log.info(`If it doesn't open, visit:\n${pc.cyan(signupUrl)}`);
-        if (!options.mock) {
-          try {
-            await open(signupUrl);
-          } catch {
-            // URL is printed above; the user can open it manually.
-          }
-        }
-        const created = await p.confirm({
-          message: 'Did you finish creating your account? Continue to log in.',
-        });
-        if (p.isCancel(created) || !created) throw new CancelledError();
-      }
-      telemetry.note('account_creation_offered', { needed: needsAccount });
-    }
-
     // 1. Login (browser flow) so we can fetch the org-specific snippet.
     const auth = await authenticate(options);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes production OAuth authorize/token parameters and login UX/timeouts in the installer’s auth path; mistakes could break login or branding, but scope is limited to the wizard CLI.
> 
> **Overview**
> **OAuth login** now sends the RFC 8707 `resource` indicator (`{api}/mcp/subtext`) on authorize and token requests so Heimdall shows **Subtext-branded** pages, and repeats it at token exchange like MCP clients. Client id resolution moves to **`oauthClientId(region)`** (env → future per-realm pre-registered ids → dynamic RFC 7591 registration).
> 
> **Browser login waiting** replaces a single silent timeout with **`waitForCallback`**: after `AUTH_PROMPT_AFTER_MS` (5 min) the CLI asks whether to keep waiting (geared to signup/email/password), while the hard cap **`AUTH_CALLBACK_TIMEOUT_MS`** rises to **60 minutes** so the loopback server stays up through long first-time flows. OAuth error HTML copy is updated; failed-login messaging points users back to re-run install.
> 
> **Wizard flow** drops the temporary pre-OAuth “create account” browser step (`SUBTEXT_SIGNUP_PATH` / signup confirms in `run.ts`), relying on OAuth-native signup instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668d9f197b8a06761e7916be9de5343bd1b8e330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->