### PR TITLE
Publish @subtext/install to the public npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate npm version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish npm package
+        run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "@subtext/install",
   "version": "0.1.0",
   "description": "Set up Subtext session capture in your app using your own coding agent",
+  "license": "MIT",
+  "homepage": "https://subtext.fullstory.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fullstorydev/subtext-wizard.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "subtext",
     "fullstory",


### PR DESCRIPTION
## What

Sets up publishing `@subtext/install` to the public npm registry, mirroring the release setup in `subtext-cli`.

### `package.json`
Adds the fields that public + provenance publishing require:
- `license`, `homepage`, `repository` (provenance won't run without a `repository` URL)
- `publishConfig: { access: "public", provenance: true }` — the package is scoped, so npm would otherwise default it to private

### `.github/workflows/release.yml` (new)
Mirrors subtext-cli's flow, adapted for this pure-Node/`tsc` package:
- Fires on `v*` tags
- Validates the git tag matches `package.json` version
- `npm ci` → `npm run build` → `npm publish --access public --provenance`
- Uses npm **trusted publishing** via OIDC (`id-token: write`) — no `NPM_TOKEN` needed, same as subtext-cli

## One-time setup required before the first release
Register the trusted publisher on npmjs.com: the `@subtext/install` package (or `@subtext` org) → **Settings → Trusted Publishing** → add GitHub Actions publisher for repo `fullstorydev/subtext-wizard`, workflow `release.yml`. (Alternatively, add an `NPM_TOKEN` secret and set `NODE_AUTH_TOKEN` on the publish step.)

## Cutting a release
```
npm version patch
git push --follow-tags
```

## Notes
- No `LICENSE` file added — subtext-cli has none either; both just declare MIT in `package.json`.
- Verified with `npm publish --dry-run`: packs 22 files, targets `registry.npmjs.org` with public access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release automation and package metadata; no runtime application logic is modified.
> 
> **Overview**
> Adds **automated public npm publishing** for `@subtext/install` when a `v*` git tag is pushed.
> 
> **`package.json`** gains MIT license, homepage, GitHub `repository` URL, and `publishConfig` with `access: "public"` and `provenance: true` so the scoped package publishes publicly with supply-chain provenance.
> 
> **`.github/workflows/release.yml`** runs on tag push: checks the tag (without `v`) matches `package.json` version, then `npm ci` → `npm run build` → `npm publish --access public --provenance`, using OIDC (`id-token: write`) for npm trusted publishing instead of an `NPM_TOKEN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cbfe5b879972c2f26dd3cca443200cca0b7e302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->