### PR TITLE
Add a plugin setup step after the prompt run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,19 @@ Previously users copied a long setup prompt into their coding agent by hand. Thi
 
 Terminal agents get the **headless** prompt variant (approval gates replaced with "use best judgment + write `subtext-setup-report.md`"). App handoffs get the **interactive** variant, which keeps every plan/identity/privacy approval gate from the original onboarding prompt.
 
-6. **Plugin setup** — after the prompt run, sets up the Subtext plugin in the same harness so the agent can review captured sessions later. Claude Code is installed automatically (`claude plugin marketplace add https://github.com/fullstorydev/subtext` + `claude plugin install subtext@subtext-marketplace`, confirm-gated unless `--agent` was passed); Cursor users are pointed at the official `/add-plugin subtext`; every other harness gets its own manual MCP server config pointing at the realm-aware `…/mcp/subtext` endpoint. Skipped when the agent run exited non-zero.
+6. **Plugin setup** — after the prompt run, the wizard writes the Subtext MCP server entry directly into the chosen harness's own config file (confirm-gated unless `--agent` was passed), pointing at the realm-aware `…/mcp/subtext` endpoint. No agent commands or slash commands involved. Project-scoped where supported, user-global otherwise:
+
+| Harness | File | Entry |
+|---|---|---|
+| Claude Code | `.mcp.json` (project) | `mcpServers.subtext` → `{type: http, url}` |
+| Cursor | `.cursor/mcp.json` (project) | `mcpServers.subtext` → `{url}` |
+| VS Code | `.vscode/mcp.json` (project) | `servers.subtext` → `{type: http, url}` |
+| Gemini CLI | `~/.gemini/settings.json` | `mcpServers.subtext` → `{httpUrl}` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers.subtext` → `{serverUrl}` |
+| Codex CLI | `~/.codex/config.toml` | `[mcp_servers.subtext]` table appended |
+| Zed / Claude Desktop / manual | — | instructions only (no file we can safely edit) |
+
+JSON configs are merged (existing keys preserved, idempotent on re-run); a file that fails to parse is never clobbered — the wizard falls back to printed instructions, which also mention the packaged plugin routes (`/plugin install subtext@subtext-marketplace` for Claude Code, `/add-plugin subtext` for Cursor) as alternatives. Skipped when the agent run exited non-zero.
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 |---|---|---|
 | Claude Code | plugin CLI: `claude plugin marketplace add …/fullstorydev/subtext` + `claude plugin install subtext@subtext-marketplace` | write `.mcp.json` (project) |
 | Cursor | instructions: `/add-plugin subtext` (official plugin) | `.cursor/mcp.json` shown in the same note |
+| Gemini CLI | extension CLI: `gemini extensions install …/fullstorydev/subtext` (repo carries `gemini-extension.json`; skips if `~/.gemini/extensions/subtext` exists) | write `~/.gemini/settings.json` `mcpServers.subtext` → `{httpUrl}` |
 | VS Code | write `.vscode/mcp.json` (project) `servers.subtext` → `{type: http, url}` | instructions |
-| Gemini CLI | write `~/.gemini/settings.json` `mcpServers.subtext` → `{httpUrl}` | instructions |
 | Windsurf | write `~/.codeium/windsurf/mcp_config.json` `mcpServers.subtext` → `{serverUrl}` | instructions |
 | Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` | instructions |
 | Zed / Claude Desktop / manual | instructions only | — |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 | Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` (updates the `url` in an existing table) | instructions |
 | Zed / Claude Desktop / manual | instructions only | — |
 
-JSON config writes are merged (existing keys preserved, idempotent on re-run); a file that fails to parse — or whose root/section isn't a JSON object — is never clobbered: the wizard falls back to printed instructions. The realm in the MCP URL comes from the org's auth token, not the `--region` flag. Skipped when the agent run exited non-zero.
+JSON config writes are merged (sibling servers and extra fields on an existing `subtext` entry preserved, idempotent on re-run); a file that fails to parse — or whose root/section isn't a JSON object — is never clobbered: the wizard falls back to printed instructions. A failed packaged install asks again before falling back to a config write. The realm in the MCP URL comes from the org's auth token, not the `--region` flag. Skipped when the agent run exited non-zero.
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 | Cursor | instructions: `/add-plugin subtext` (official plugin) | `.cursor/mcp.json` shown in the same note |
 | Gemini CLI | extension CLI: `gemini extensions install …/fullstorydev/subtext` (repo carries `gemini-extension.json`; skips if `~/.gemini/extensions/subtext` exists) | write `~/.gemini/settings.json` `mcpServers.subtext` → `{httpUrl}` |
 | VS Code | write `.vscode/mcp.json` (project) `servers.subtext` → `{type: http, url}` | instructions |
-| Devin Desktop | write `.devin/config.json` (project) `mcpServers.subtext` → `{url, transport: http}` | instructions (`devin mcp add`) |
+| Devin Desktop | write `~/.codeium/windsurf/mcp_config.json` `mcpServers.subtext` → `{serverUrl}` (read by Cascade) | instructions (incl. `devin mcp add` for the Devin CLI harness) |
 | Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` | instructions |
 | Zed / Claude Desktop / manual | instructions only | — |
 

--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ Previously users copied a long setup prompt into their coding agent by hand. Thi
 
 Terminal agents get the **headless** prompt variant (approval gates replaced with "use best judgment + write `subtext-setup-report.md`"). App handoffs get the **interactive** variant, which keeps every plan/identity/privacy approval gate from the original onboarding prompt.
 
-6. **Plugin setup** — after the prompt run, the wizard writes the Subtext MCP server entry directly into the chosen harness's own config file (confirm-gated unless `--agent` was passed), pointing at the realm-aware `…/mcp/subtext` endpoint. No agent commands or slash commands involved. Project-scoped where supported, user-global otherwise:
+6. **Plugin setup** — after the prompt run, the wizard wires Subtext into the chosen harness (confirm-gated unless `--agent` was passed). The packaged **plugin is the primary route wherever one exists** — it bundles the skills (proof, review, live…) on top of the MCP server; harnesses without a plugin get the raw MCP server entry (tools only) written directly into their own config file, pointing at the realm-aware `…/mcp/subtext` endpoint:
 
-| Harness | File | Entry |
+| Harness | Primary | Fallback |
 |---|---|---|
-| Claude Code | `.mcp.json` (project) | `mcpServers.subtext` → `{type: http, url}` |
-| Cursor | `.cursor/mcp.json` (project) | `mcpServers.subtext` → `{url}` |
-| VS Code | `.vscode/mcp.json` (project) | `servers.subtext` → `{type: http, url}` |
-| Gemini CLI | `~/.gemini/settings.json` | `mcpServers.subtext` → `{httpUrl}` |
-| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers.subtext` → `{serverUrl}` |
-| Codex CLI | `~/.codex/config.toml` | `[mcp_servers.subtext]` table appended |
-| Zed / Claude Desktop / manual | — | instructions only (no file we can safely edit) |
+| Claude Code | plugin CLI: `claude plugin marketplace add …/fullstorydev/subtext` + `claude plugin install subtext@subtext-marketplace` | write `.mcp.json` (project) |
+| Cursor | instructions: `/add-plugin subtext` (official plugin) | `.cursor/mcp.json` shown in the same note |
+| VS Code | write `.vscode/mcp.json` (project) `servers.subtext` → `{type: http, url}` | instructions |
+| Gemini CLI | write `~/.gemini/settings.json` `mcpServers.subtext` → `{httpUrl}` | instructions |
+| Windsurf | write `~/.codeium/windsurf/mcp_config.json` `mcpServers.subtext` → `{serverUrl}` | instructions |
+| Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` | instructions |
+| Zed / Claude Desktop / manual | instructions only | — |
 
-JSON configs are merged (existing keys preserved, idempotent on re-run); a file that fails to parse is never clobbered — the wizard falls back to printed instructions, which also mention the packaged plugin routes (`/plugin install subtext@subtext-marketplace` for Claude Code, `/add-plugin subtext` for Cursor) as alternatives. Skipped when the agent run exited non-zero.
+JSON config writes are merged (existing keys preserved, idempotent on re-run); a file that fails to parse is never clobbered — the wizard falls back to printed instructions. Skipped when the agent run exited non-zero.
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 | Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` (updates the `url` in an existing table) | instructions |
 | Zed / Claude Desktop / manual | instructions only | — |
 
-JSON config writes are merged (sibling servers and extra fields on an existing `subtext` entry preserved, idempotent on re-run); a file that fails to parse — or whose root/section isn't a JSON object — is never clobbered: the wizard falls back to printed instructions. A failed packaged install asks again before falling back to a config write. The realm in the MCP URL comes from the org's auth token, not the `--region` flag. Skipped when the agent run exited non-zero.
+JSON config writes are merged (sibling servers and extra fields on an existing `subtext` entry preserved, idempotent on re-run); a file that fails to parse — or whose root/section isn't a JSON object — is never clobbered: the wizard falls back to printed instructions. A failed packaged install asks again before falling back to a config write; once a packaged install succeeds (or is detected), a raw fallback entry left by an earlier run is removed (matched by its Subtext endpoint URL) so the harness doesn't load the server twice. The realm in the MCP URL comes from the org's auth token, not the `--region` flag. Skipped when the agent run exited non-zero.
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Auth and snippet use **real production endpoints** (audited against the `mn` mon
 - `https://api.fullstory.com/code/v2/snippet?org=…&type=CORE` — public org snippet (`api.eu1.…` for EU orgs)
 - `https://telemetry.subtext.fullstory.com/v1/wizard-events` — **PLACEHOLDER**, no backend yet
 
-Overridable via env vars (`SUBTEXT_AUTH_BASE_URL`, `SUBTEXT_API_BASE_URL`, `SUBTEXT_TELEMETRY_URL`, `SUBTEXT_OAUTH_CLIENT_ID`, `SUBTEXT_OAUTH_SCOPES`). Use `--mock` to run the whole flow offline with canned auth and the example snippet. Remaining backend work (pre-registered OAuth client, scope decision, telemetry ingest, org-aware snippet for custom-host orgs) is itemized in `docs/notion-wizard-plan.md`.
+Overridable via env vars (`SUBTEXT_AUTH_BASE_URL`, `SUBTEXT_API_BASE_URL`, `SUBTEXT_TELEMETRY_URL`, `SUBTEXT_OAUTH_CLIENT_ID`, `SUBTEXT_OAUTH_SCOPES`). Use `--mock` to run the whole flow offline with canned auth and the example snippet; it also skips the real agent run and plugin install (both logged instead), so the full flow — including the plugin step — can be previewed without side effects. Remaining backend work (pre-registered OAuth client, scope decision, telemetry ingest, org-aware snippet for custom-host orgs) is itemized in `docs/notion-wizard-plan.md`.
 
 ## Flags
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Previously users copied a long setup prompt into their coding agent by hand. Thi
 
 Terminal agents get the **headless** prompt variant (approval gates replaced with "use best judgment + write `subtext-setup-report.md`"). App handoffs get the **interactive** variant, which keeps every plan/identity/privacy approval gate from the original onboarding prompt.
 
+6. **Plugin setup** — after the prompt run, sets up the Subtext plugin in the same harness so the agent can review captured sessions later. Claude Code is installed automatically (`claude plugin marketplace add https://github.com/fullstorydev/subtext` + `claude plugin install subtext@subtext-marketplace`, confirm-gated unless `--agent` was passed); Cursor users are pointed at the official `/add-plugin subtext`; every other harness gets its own manual MCP server config pointing at the realm-aware `…/mcp/subtext` endpoint. Skipped when the agent run exited non-zero.
+
 ## Telemetry
 
 Two layers, both fire-and-forget and disabled by `--no-telemetry`:
@@ -86,5 +88,6 @@ src/snippet.ts                Org snippet fetch (public snippet service)
 src/integrations.ts           Integration catalog + multiselect
 src/prompt/build.ts           Prompt assembly (headless vs interactive variants)
 src/agents/                   Agent detection + launch strategies
+src/pluginSetup.ts            Post-run Subtext plugin / MCP server setup
 src/telemetry.ts              Fire-and-forget event reporting
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Previously users copied a long setup prompt into their coding agent by hand. Thi
 | Claude Code | terminal | Runs headless in the same terminal (`claude -p`, prompt on stdin, `--permission-mode acceptEdits`, streamed `stream-json` progress) |
 | Codex CLI | terminal | Runs headless (`codex exec --full-auto`) |
 | Gemini CLI | terminal | Runs headless (`gemini --yolo -p`) |
-| Cursor / Windsurf / VS Code / Zed | app | Copies the prompt to the clipboard, opens the app at the project folder, shows paste instructions |
+| Cursor / Devin Desktop / VS Code / Zed | app | Copies the prompt to the clipboard, opens the app at the project folder, shows paste instructions |
 | Claude Desktop | app | Copies the prompt, opens the app, shows paste instructions |
 | None detected | — | Copies the prompt to the clipboard / prints it |
 
@@ -35,11 +35,11 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 | Cursor | instructions: `/add-plugin subtext` (official plugin) | `.cursor/mcp.json` shown in the same note |
 | Gemini CLI | extension CLI: `gemini extensions install …/fullstorydev/subtext` (repo carries `gemini-extension.json`; skips if `~/.gemini/extensions/subtext` exists) | write `~/.gemini/settings.json` `mcpServers.subtext` → `{httpUrl}` |
 | VS Code | write `.vscode/mcp.json` (project) `servers.subtext` → `{type: http, url}` | instructions |
-| Windsurf | write `~/.codeium/windsurf/mcp_config.json` `mcpServers.subtext` → `{serverUrl}` | instructions |
+| Devin Desktop | write `.devin/config.json` (project) `mcpServers.subtext` → `{url, transport: http}` | instructions (`devin mcp add`) |
 | Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` | instructions |
 | Zed / Claude Desktop / manual | instructions only | — |
 
-JSON config writes are merged (existing keys preserved, idempotent on re-run); a file that fails to parse is never clobbered — the wizard falls back to printed instructions. Skipped when the agent run exited non-zero.
+JSON config writes are merged (existing keys preserved, idempotent on re-run); a file that fails to parse — or whose root/section isn't a JSON object — is never clobbered: the wizard falls back to printed instructions. The realm in the MCP URL comes from the org's auth token, not the `--region` flag. Skipped when the agent run exited non-zero.
 
 ## Telemetry
 
@@ -65,7 +65,7 @@ Overridable via env vars (`SUBTEXT_AUTH_BASE_URL`, `SUBTEXT_API_BASE_URL`, `SUBT
 --region <us|eu>        Data region for login and API hosts (default: us)
 --api-key <key>         Skip browser login (OAuth access tokens only)
 --agent <id>            Skip the agent picker (claude-code, codex, gemini, cursor,
-                        windsurf, vscode, zed, claude-desktop, manual)
+                        devin, vscode, zed, claude-desktop, manual)
 --integrations <list>   Skip the multiselect (unknown names become "Other")
 --print-prompt          Print the assembled prompt instead of launching
 --mock                  No network calls

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 |---|---|---|
 | Claude Code | plugin CLI: `claude plugin marketplace add …/fullstorydev/subtext` + `claude plugin install subtext@subtext-marketplace` | write `.mcp.json` (project) |
 | Cursor | instructions: `/add-plugin subtext` (official plugin) | `.cursor/mcp.json` shown in the same note |
-| Gemini CLI | extension CLI: `gemini extensions install …/fullstorydev/subtext` (repo carries `gemini-extension.json`; skips if `~/.gemini/extensions/subtext` exists) | write `~/.gemini/settings.json` `mcpServers.subtext` → `{httpUrl}` |
+| Gemini CLI | extension CLI: `gemini extensions install …/fullstorydev/subtext` (repo carries `gemini-extension.json`; skips if `~/.gemini/extensions/subtext` exists) | write `~/.gemini/settings.json` `mcpServers.subtext` → `{url, type: http}` |
 | VS Code | write `.vscode/mcp.json` (project) `servers.subtext` → `{type: http, url}` | instructions |
 | Devin Desktop | write `~/.codeium/windsurf/mcp_config.json` `mcpServers.subtext` → `{serverUrl}` (read by Cascade) | instructions (incl. `devin mcp add` for the Devin CLI harness) |
-| Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` | instructions |
+| Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` (updates the `url` in an existing table) | instructions |
 | Zed / Claude Desktop / manual | instructions only | — |
 
 JSON config writes are merged (existing keys preserved, idempotent on re-run); a file that fails to parse — or whose root/section isn't a JSON object — is never clobbered: the wizard falls back to printed instructions. The realm in the MCP URL comes from the org's auth token, not the `--region` flag. Skipped when the agent run exited non-zero.

--- a/src/agents/apps.ts
+++ b/src/agents/apps.ts
@@ -96,13 +96,15 @@ export const cursor = makeAppAgent({
   pasteHint: ['Open the agent pane (Cmd+I / Ctrl+I) and paste the prompt.'],
 });
 
-export const windsurf = makeAppAgent({
-  id: 'windsurf',
-  name: 'Windsurf',
-  cliCommand: 'windsurf',
-  macAppName: 'Windsurf',
+// Windsurf became Devin Desktop after Cognition's acquisition (June 2026):
+// same editor, `devin-desktop` shell command, Devin.app bundle on macOS.
+export const devin = makeAppAgent({
+  id: 'devin',
+  name: 'Devin Desktop',
+  cliCommand: 'devin-desktop',
+  macAppName: 'Devin',
   opensFolder: true,
-  pasteHint: ['Open Cascade (Cmd+L / Ctrl+L) and paste the prompt.'],
+  pasteHint: ['Open the agent panel (Cascade, Cmd+L / Ctrl+L) and paste the prompt.'],
 });
 
 export const vscode = makeAppAgent({

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import type { WizardOptions } from '../config.js';
 import { CancelledError } from '../integrations.js';
-import { claudeDesktop, cursor, vscode, windsurf, zed } from './apps.js';
+import { claudeDesktop, cursor, devin, vscode, zed } from './apps.js';
 import { claudeCode } from './claude-code.js';
 import { codexCli } from './codex.js';
 import { geminiCli } from './gemini.js';
@@ -14,7 +14,7 @@ export const AGENTS: AgentDefinition[] = [
   codexCli,
   geminiCli,
   cursor,
-  windsurf,
+  devin,
   vscode,
   zed,
   claudeDesktop,
@@ -45,7 +45,7 @@ export async function chooseAgent(
 
   if (detected.length === 0) {
     p.log.warn(
-      'No coding agent detected (looked for Claude Code, Codex CLI, Gemini CLI, Cursor, Windsurf, VS Code, Zed, Claude Desktop).',
+      'No coding agent detected (looked for Claude Code, Codex CLI, Gemini CLI, Cursor, Devin Desktop, VS Code, Zed, Claude Desktop).',
     );
     return MANUAL_CHOICE;
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -72,7 +72,7 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
       accessToken: 'subtext_mock_token',
       orgId: 'o-1G1-na1',
       userEmail: 'demo@example.com',
-      region: 'us',
+      region: options.region,
     };
   }
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -15,7 +15,7 @@ Options:
   --region <us|eu>        Data region for login and API hosts (default: us)
   --api-key <key>         Skip the browser login and use this OAuth access token
   --agent <id>            Skip the agent picker (claude-code, codex, gemini, cursor,
-                          windsurf, vscode, zed, claude-desktop, manual)
+                          devin, vscode, zed, claude-desktop, manual)
   --integrations <list>   Comma-separated integrations to target, skips the picker
                           (posthog, amplitude, mixpanel, statsig, sentry, logrocket,
                           datadog, launchdarkly, growthbook, intercom, pendo, appcues,

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,12 @@ export function oauthClientId(region: Region): string | undefined {
  */
 export const OAUTH_SCOPES = process.env.SUBTEXT_OAUTH_SCOPES ?? 'sessions:read';
 
+/** Subtext MCP server endpoint, realm-aware. This is the URL agents connect
+ * to once the plugin (or a manual MCP server entry) is configured. */
+export function subtextMcpUrl(region: Region): string {
+  return `${apiBaseUrl(region)}/mcp/subtext`;
+}
+
 /**
  * RFC 8707 resource indicator sent on the authorization and token requests,
  * identifying the Subtext MCP resource. Heimdall keys the Subtext branding
@@ -74,7 +80,7 @@ export const OAUTH_SCOPES = process.env.SUBTEXT_OAUTH_SCOPES ?? 'sessions:read';
  * so the wizard's login gets the same branded flow they do.
  */
 export function subtextOauthResource(region: Region): string {
-  return `${apiBaseUrl(region)}/mcp/subtext`;
+  return subtextMcpUrl(region);
 }
 
 /** Public, unauthenticated snippet endpoint (snippet service). `type=CORE`

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -103,7 +103,9 @@ function jsonConfigWrite(
 
 /**
  * Codex config is TOML, which we don't parse — append the server table if
- * it isn't there yet, and leave an existing one alone.
+ * it isn't there yet. When the table already exists, rewrite just its
+ * `url` line so a realm change on a re-run doesn't leave a stale host;
+ * a table we can't find the url in falls back to instructions.
  */
 function codexConfigWrite(file: string, url: string): ConfigWrite {
   return {
@@ -115,10 +117,27 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
       }
-      if (existing.includes('[mcp_servers.subtext]')) return 'unchanged';
+      const header = '[mcp_servers.subtext]';
+      const headerAt = existing.indexOf(header);
+      if (headerAt >= 0) {
+        const tableStart = headerAt + header.length;
+        const nextTable = existing.indexOf('\n[', tableStart);
+        const tableEnd = nextTable === -1 ? existing.length : nextTable;
+        const table = existing.slice(tableStart, tableEnd);
+        const urlLine = /^(\s*url\s*=\s*)"[^"]*"/m;
+        if (!urlLine.test(table)) return 'unparseable';
+        const updated = table.replace(urlLine, (_, prefix: string) => `${prefix}"${url}"`);
+        if (updated === table) return 'unchanged';
+        await fs.writeFile(
+          file,
+          existing.slice(0, tableStart) + updated + existing.slice(tableEnd),
+          'utf8',
+        );
+        return 'written';
+      }
       const block = `${existing && !existing.endsWith('\n') ? '\n' : ''}${
         existing ? '\n' : ''
-      }[mcp_servers.subtext]\nurl = "${url}"\n`;
+      }${header}\nurl = "${url}"\n`;
       await fs.mkdir(path.dirname(file), { recursive: true });
       await fs.writeFile(file, existing + block, 'utf8');
       return 'written';
@@ -147,8 +166,11 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
         url,
       });
     case 'gemini':
+      // `url` + explicit `type` is the consolidated schema (the old
+      // `httpUrl` field is deprecated, kept only as a compat fallback).
       return jsonConfigWrite(path.join(home, '.gemini', 'settings.json'), 'mcpServers', {
-        httpUrl: url,
+        url,
+        type: 'http',
       });
     case 'devin':
       // Cascade — the panel the handoff points at — kept Windsurf's config
@@ -197,7 +219,7 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         `  gemini extensions install ${PLUGIN_REPO_URL}`,
         '',
         'Prefer a raw MCP server? Add this to ~/.gemini/settings.json:',
-        ...indent(JSON.stringify({ mcpServers: { subtext: { httpUrl: url } } }, null, 2)),
+        ...indent(JSON.stringify({ mcpServers: { subtext: { url, type: 'http' } } }, null, 2)),
       ];
     case 'devin':
       return [

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -61,6 +61,16 @@ interface ConfigWrite {
   /** Config file the server entry goes into. */
   file: string;
   write(): Promise<WriteOutcome>;
+  /** Remove a subtext entry this wizard previously wrote — recognized by
+   * its URL pointing at one of our realm endpoints, so a user's custom
+   * entry is left alone. Used when a packaged plugin supersedes a raw
+   * fallback entry from an earlier run. Returns whether it removed one. */
+  removeOurs?(): Promise<boolean>;
+}
+
+/** Both realm endpoints — used to recognize entries we wrote. */
+function subtextUrls(): string[] {
+  return [subtextMcpUrl('us'), subtextMcpUrl('eu')];
 }
 
 type JsonObject = Record<string, unknown>;
@@ -108,6 +118,26 @@ function jsonConfigWrite(
       await fs.mkdir(path.dirname(file), { recursive: true });
       await fs.writeFile(file, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
       return 'written';
+    },
+    async removeOurs() {
+      let config: JsonObject;
+      try {
+        const parsed: unknown = JSON.parse(await fs.readFile(file, 'utf8'));
+        if (!isPlainObject(parsed)) return false;
+        config = parsed;
+      } catch {
+        return false;
+      }
+      const servers = config[section];
+      if (!isPlainObject(servers) || !isPlainObject(servers.subtext)) return false;
+      const { url, httpUrl, serverUrl } = servers.subtext;
+      const endpoint = [url, httpUrl, serverUrl].find(
+        (v): v is string => typeof v === 'string',
+      );
+      if (!endpoint || !subtextUrls().includes(endpoint)) return false;
+      delete servers.subtext;
+      await fs.writeFile(file, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+      return true;
     },
   };
 }
@@ -338,7 +368,9 @@ function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): Packaged
           `claude plugin install ${PLUGIN_SPEC}`,
         ],
         // `claude plugin install` records installs in installed_plugins.json,
-        // keyed by <plugin>@<marketplace> — the same spec we install.
+        // keyed by <plugin>@<marketplace> — the same spec we install. A
+        // user-scoped install applies everywhere; project/local ones only
+        // count when they're for the directory being instrumented.
         alreadyInstalled: async () => {
           try {
             const installed = JSON.parse(
@@ -347,8 +379,15 @@ function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): Packaged
                 'utf8',
               ),
             ) as { plugins?: Record<string, unknown> };
-            const entry = installed.plugins?.[PLUGIN_SPEC];
-            return Array.isArray(entry) && entry.length > 0;
+            const entries = installed.plugins?.[PLUGIN_SPEC];
+            if (!Array.isArray(entries)) return false;
+            return entries.some(
+              (entry) =>
+                isPlainObject(entry) &&
+                (entry.scope === 'user' ||
+                  (typeof entry.projectPath === 'string' &&
+                    path.resolve(entry.projectPath) === path.resolve(options.dir))),
+            );
           } catch {
             return false;
           }
@@ -414,6 +453,31 @@ async function applyConfigWrite(
   );
 }
 
+/**
+ * A working packaged plugin supersedes any raw fallback entry left by an
+ * earlier run — drop it so the harness doesn't load Subtext twice.
+ * Best-effort: only removes an entry whose URL is one of our endpoints.
+ */
+async function removeSupersededRawEntry(
+  agentId: string,
+  dir: string,
+  region: Region,
+): Promise<void> {
+  const target = configWrite(agentId, dir, region);
+  if (!target?.removeOurs) return;
+  try {
+    if (await target.removeOurs()) {
+      p.log.info(
+        pc.dim(
+          `Removed the raw MCP server entry from ${prettyPath(target.file)} — the plugin supersedes it.`,
+        ),
+      );
+    }
+  } catch {
+    // duplicate tools are annoying but not worth failing the step over
+  }
+}
+
 /** Packaged plugin path: install via the harness's own CLI, raw entry on failure. */
 async function packagedPluginSetup(
   plugin: PackagedPlugin,
@@ -429,6 +493,7 @@ async function packagedPluginSetup(
   // shouldn't prompt for (or count a decline against) a plugin that's
   // already there. Skipped in mock mode, which never reads real state.
   if (!options.mock && (await plugin.alreadyInstalled())) {
+    await removeSupersededRawEntry(agentId, options.dir, region);
     onEvent('plugin_setup_completed', { agent: agentId, method: 'already-installed' });
     p.log.success(`Subtext plugin already installed in ${agentName}.`);
     return;
@@ -465,6 +530,7 @@ async function packagedPluginSetup(
     // fall through to the raw MCP server entry
   }
   if (installed) {
+    await removeSupersededRawEntry(agentId, options.dir, region);
     onEvent('plugin_setup_completed', { agent: agentId, method: 'plugin-cli' });
     p.log.success(
       `Subtext plugin installed — available in your next ${agentName} session.`,

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -92,8 +92,18 @@ function jsonConfigWrite(
       }
       if (config[section] != null && !isPlainObject(config[section])) return 'unparseable';
       const servers = (config[section] ??= {}) as JsonObject;
-      if (JSON.stringify(servers.subtext) === JSON.stringify(entry)) return 'unchanged';
-      servers.subtext = entry;
+      // Merge on top of an existing entry so user extras (headers, disabled,
+      // timeouts…) survive a re-run, but drop competing transport fields we
+      // aren't setting — e.g. a deprecated httpUrl next to the new url.
+      const merged: JsonObject = {
+        ...(isPlainObject(servers.subtext) ? servers.subtext : {}),
+        ...entry,
+      };
+      for (const key of ['url', 'httpUrl', 'serverUrl', 'type', 'transport', 'command', 'args']) {
+        if (!(key in entry)) delete merged[key];
+      }
+      if (JSON.stringify(servers.subtext) === JSON.stringify(merged)) return 'unchanged';
+      servers.subtext = merged;
       await fs.mkdir(path.dirname(file), { recursive: true });
       await fs.writeFile(file, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
       return 'written';
@@ -117,12 +127,15 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
       }
-      const header = '[mcp_servers.subtext]';
-      const headerAt = existing.indexOf(header);
-      if (headerAt >= 0) {
-        const tableStart = headerAt + header.length;
-        const nextTable = existing.indexOf('\n[', tableStart);
-        const tableEnd = nextTable === -1 ? existing.length : nextTable;
+      // Line-anchored so the header inside a comment or string doesn't count.
+      const headerRe = /^[ \t]*\[mcp_servers\.subtext\][ \t]*(?:#.*)?$/m;
+      const headerMatch = headerRe.exec(existing);
+      if (headerMatch) {
+        const tableStart = headerMatch.index + headerMatch[0].length;
+        const nextTableRe = /\n[ \t]*\[/g;
+        nextTableRe.lastIndex = tableStart;
+        const nextTable = nextTableRe.exec(existing);
+        const tableEnd = nextTable ? nextTable.index : existing.length;
         const table = existing.slice(tableStart, tableEnd);
         const urlLine = /^(\s*url\s*=\s*)"[^"]*"/m;
         if (!urlLine.test(table)) return 'unparseable';
@@ -137,7 +150,7 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
       }
       const block = `${existing && !existing.endsWith('\n') ? '\n' : ''}${
         existing ? '\n' : ''
-      }${header}\nurl = "${url}"\n`;
+      }[mcp_servers.subtext]\nurl = "${url}"\n`;
       await fs.mkdir(path.dirname(file), { recursive: true });
       await fs.writeFile(file, existing + block, 'utf8');
       return 'written';
@@ -440,8 +453,22 @@ async function packagedPluginSetup(
     return;
   }
 
-  p.log.warn('Plugin install failed — falling back to a raw MCP server entry (tools only).');
+  p.log.warn('Plugin install failed — a raw MCP server entry (tools only) can be added instead.');
   const target = configWrite(agentId, options.dir, region)!;
+  // The user approved the plugin install, not a config-file edit — ask
+  // again before touching a different file (same --agent bypass as above).
+  let fallback = true;
+  if (!options.agent) {
+    const answer = await p.confirm({
+      message: `Add the Subtext MCP server to ${prettyPath(target.file)} instead?`,
+    });
+    fallback = !p.isCancel(answer) && answer;
+  }
+  if (!fallback) {
+    onEvent('plugin_setup_declined', { agent: agentId });
+    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it later');
+    return;
+  }
   await applyConfigWrite(target, agentId, agentName, region, onEvent, 'config-write-fallback');
 }
 

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -261,6 +261,8 @@ async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise
 interface PackagedPlugin {
   /** Confirm-prompt fragment describing what the install brings. */
   confirmHint: string;
+  /** The commands install() runs, for mock-mode display. */
+  commands: string[];
   /** Fast local check for an existing install, so re-runs don't fall back
    * into writing a duplicate raw server entry. */
   alreadyInstalled(): Promise<boolean>;
@@ -275,6 +277,10 @@ function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): Packaged
     case 'claude-code':
       return {
         confirmHint: 'session-review tools plus the proof/review skills',
+        commands: [
+          `claude plugin marketplace add ${PLUGIN_REPO_URL}`,
+          `claude plugin install ${PLUGIN_SPEC}`,
+        ],
         // No cheap local check; `plugin install` handles re-runs itself.
         alreadyInstalled: async () => false,
         install: () => installClaudeCodePlugin(binaryPath, options.dir),
@@ -282,6 +288,7 @@ function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): Packaged
     case 'gemini':
       return {
         confirmHint: 'installs the Subtext extension with its MCP servers',
+        commands: [`gemini extensions install ${PLUGIN_REPO_URL}`],
         alreadyInstalled: async () => {
           try {
             await fs.access(path.join(os.homedir(), '.gemini', 'extensions', 'subtext'));
@@ -363,7 +370,9 @@ async function packagedPluginSetup(
   }
 
   if (options.mock) {
-    p.log.info(pc.dim('Mock mode: skipping the real plugin install.'));
+    p.log.info(
+      pc.dim(`Mock mode: would run\n  ${plugin.commands.join('\n  ')}`),
+    );
     onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
     return;
   }

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -15,16 +15,18 @@ import { subtextMcpUrl } from './config.js';
  * captured sessions in later conversations.
  *
  * The packaged plugin is preferred wherever one exists, because it bundles
- * the skills (proof, review, live…) on top of the MCP server: Claude Code
- * installs it via its plugin CLI, Cursor via the official /add-plugin.
- * Harnesses without a plugin get the raw MCP server entry written straight
- * into their own config file — tools only, no agent commands involved.
- * Harnesses without a file we can safely edit (Zed, Claude Desktop,
- * unknown) get instructions instead, as do declines and unparseable
- * configs.
+ * more than the MCP server (skills for Claude Code, both realm servers for
+ * Gemini): Claude Code and Gemini CLI install it via their own CLIs, Cursor
+ * via the official /add-plugin. Harnesses without a plugin get the raw MCP
+ * server entry written straight into their own config file — tools only,
+ * no agent commands involved. Harnesses without a file we can safely edit
+ * (Zed, Claude Desktop, unknown) get instructions instead, as do declines
+ * and unparseable configs.
  */
 
-export const PLUGIN_MARKETPLACE_URL = 'https://github.com/fullstorydev/subtext';
+/** The plugin repo: Claude Code marketplace and Gemini extension
+ * (gemini-extension.json) in one. */
+export const PLUGIN_REPO_URL = 'https://github.com/fullstorydev/subtext';
 export const PLUGIN_SPEC = 'subtext@subtext-marketplace';
 
 const WHY_PLUGIN =
@@ -122,7 +124,8 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
  * user-global otherwise. Returns null when there's no file we can safely
  * edit — those harnesses get instructions. Cursor is deliberately absent:
  * its packaged plugin (/add-plugin subtext) is the primary route, so it
- * goes through instructions rather than a config write.
+ * goes through instructions rather than a config write. Claude Code and
+ * Gemini entries are the fallbacks behind their packaged plugin installs.
  */
 function configWrite(agentId: string, dir: string, region: Region): ConfigWrite | null {
   const url = subtextMcpUrl(region);
@@ -156,14 +159,14 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
 // Instruction fallbacks
 // ---------------------------------------------------------------------------
 
-/** Harness-specific instructions for adding the server by hand. */
+/** Harness-specific instructions for adding the plugin/server by hand. */
 function pluginInstructions(agentId: string, region: Region): string[] {
   const url = subtextMcpUrl(region);
   switch (agentId) {
     case 'claude-code':
       return [
         'In a Claude Code session, run (installs tools + skills):',
-        `  /plugin marketplace add ${PLUGIN_MARKETPLACE_URL}`,
+        `  /plugin marketplace add ${PLUGIN_REPO_URL}`,
         `  /plugin install ${PLUGIN_SPEC}`,
         '',
         'Prefer a raw MCP server (tools only)? Add this to .mcp.json in the project:',
@@ -177,6 +180,14 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         'Prefer a raw MCP server (tools only)? Add this to .cursor/mcp.json in the project:',
         ...indent(JSON.stringify({ mcpServers: { subtext: { url } } }, null, 2)),
       ];
+    case 'gemini':
+      return [
+        'Install the Subtext extension (bundles the MCP servers):',
+        `  gemini extensions install ${PLUGIN_REPO_URL}`,
+        '',
+        'Prefer a raw MCP server? Add this to ~/.gemini/settings.json:',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { httpUrl: url } } }, null, 2)),
+      ];
     case 'claude-desktop':
       return [
         'In Claude Desktop: Settings → Connectors → Add custom connector,',
@@ -187,11 +198,6 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         'Add the Subtext MCP server to ~/.codex/config.toml:',
         '  [mcp_servers.subtext]',
         `  url = "${url}"`,
-      ];
-    case 'gemini':
-      return [
-        'Add the Subtext MCP server to ~/.gemini/settings.json:',
-        ...indent(JSON.stringify({ mcpServers: { subtext: { httpUrl: url } } }, null, 2)),
       ];
     case 'vscode':
       return [
@@ -210,11 +216,14 @@ function pluginInstructions(agentId: string, region: Region): string[] {
 function manualChoiceInstructions(region: Region): string[] {
   return [
     'Claude Code — run in a session (installs tools + skills):',
-    `  /plugin marketplace add ${PLUGIN_MARKETPLACE_URL}`,
+    `  /plugin marketplace add ${PLUGIN_REPO_URL}`,
     `  /plugin install ${PLUGIN_SPEC}`,
     '',
     'Cursor — run in the agent pane (installs tools + skills):',
     '  /add-plugin subtext',
+    '',
+    'Gemini CLI — install the extension:',
+    `  gemini extensions install ${PLUGIN_REPO_URL}`,
     '',
     'Any other MCP-capable agent — add this server config (tools only):',
     ...indent(manualMcpConfig(region)),
@@ -222,7 +231,7 @@ function manualChoiceInstructions(region: Region): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// The wizard step
+// Packaged plugin installs
 // ---------------------------------------------------------------------------
 
 /**
@@ -233,7 +242,7 @@ function manualChoiceInstructions(region: Region): string[] {
 async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise<boolean> {
   const addExit = await runTerminalAgent({
     binaryPath,
-    args: ['plugin', 'marketplace', 'add', PLUGIN_MARKETPLACE_URL],
+    args: ['plugin', 'marketplace', 'add', PLUGIN_REPO_URL],
     cwd,
     stdout: 'inherit',
   });
@@ -249,53 +258,65 @@ async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise
   return installExit === 0;
 }
 
-/**
- * Claude Code path: the packaged plugin first — it carries the skills, not
- * just the MCP tools — and the raw .mcp.json entry only if that fails.
- */
-async function claudeCodePluginSetup(
-  chosen: DetectedAgent,
+interface PackagedPlugin {
+  /** Confirm-prompt fragment describing what the install brings. */
+  confirmHint: string;
+  /** Fast local check for an existing install, so re-runs don't fall back
+   * into writing a duplicate raw server entry. */
+  alreadyInstalled(): Promise<boolean>;
+  install(): Promise<boolean>;
+}
+
+/** The scriptable plugin install for this harness, if it has one. */
+function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): PackagedPlugin | null {
+  const { binaryPath } = chosen;
+  if (!binaryPath) return null;
+  switch (chosen.definition.id) {
+    case 'claude-code':
+      return {
+        confirmHint: 'session-review tools plus the proof/review skills',
+        // No cheap local check; `plugin install` handles re-runs itself.
+        alreadyInstalled: async () => false,
+        install: () => installClaudeCodePlugin(binaryPath, options.dir),
+      };
+    case 'gemini':
+      return {
+        confirmHint: 'installs the Subtext extension with its MCP servers',
+        alreadyInstalled: async () => {
+          try {
+            await fs.access(path.join(os.homedir(), '.gemini', 'extensions', 'subtext'));
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        install: async () =>
+          (await runTerminalAgent({
+            binaryPath,
+            args: ['extensions', 'install', PLUGIN_REPO_URL],
+            cwd: options.dir,
+            stdout: 'inherit',
+          })) === 0,
+      };
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The wizard step
+// ---------------------------------------------------------------------------
+
+/** Write the raw server entry and report; instructions if the file resists. */
+async function applyConfigWrite(
+  target: ConfigWrite,
+  agentId: string,
+  agentName: string,
   options: WizardOptions,
   onEvent: (event: string, properties?: Record<string, unknown>) => void,
+  method: string,
 ): Promise<void> {
-  let install = true;
-  if (!options.agent) {
-    const answer = await p.confirm({
-      message: `Install the Subtext plugin in Claude Code? ${pc.dim(
-        '(session-review tools plus the proof/review skills)',
-      )}`,
-    });
-    install = !p.isCancel(answer) && answer;
-  }
-  if (!install) {
-    onEvent('plugin_setup_declined', { agent: 'claude-code' });
-    p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Install it later');
-    return;
-  }
-
-  if (options.mock) {
-    p.log.info(pc.dim('Mock mode: skipping the real plugin install.'));
-    onEvent('plugin_setup_completed', { agent: 'claude-code', method: 'mock' });
-    return;
-  }
-
-  p.log.step('Installing the Subtext plugin in Claude Code…');
-  let installed = false;
-  try {
-    installed = await installClaudeCodePlugin(chosen.binaryPath!, options.dir);
-  } catch {
-    // fall through to the raw MCP server entry
-  }
-  if (installed) {
-    onEvent('plugin_setup_completed', { agent: 'claude-code', method: 'plugin-cli' });
-    p.log.success(
-      'Subtext plugin installed — tools and skills are available in your next Claude Code session.',
-    );
-    return;
-  }
-
-  p.log.warn('Plugin install failed — falling back to a raw MCP server entry (tools only).');
-  const target = configWrite('claude-code', options.dir, options.region)!;
+  const shownPath = prettyPath(target.file);
   let outcome: WriteOutcome;
   try {
     outcome = await target.write();
@@ -303,16 +324,74 @@ async function claudeCodePluginSetup(
     outcome = 'unparseable';
   }
   if (outcome === 'unparseable') {
-    onEvent('plugin_setup_failed', { agent: 'claude-code' });
-    p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Add it by hand');
+    onEvent('plugin_setup_failed', { agent: agentId });
+    p.log.warn(`Could not update ${shownPath} — it may have a format we can't merge safely.`);
+    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Add it by hand');
     return;
   }
-  onEvent('plugin_setup_completed', { agent: 'claude-code', method: 'config-write-fallback' });
+  onEvent('plugin_setup_completed', { agent: agentId, method });
   p.log.success(
     outcome === 'written'
-      ? `Subtext MCP server added to ${prettyPath(target.file)} — picked up the next time Claude Code starts here.`
-      : `Subtext MCP server already configured in ${prettyPath(target.file)}.`,
+      ? `Subtext MCP server added to ${shownPath} — picked up the next time ${agentName} starts here.`
+      : `Subtext MCP server already configured in ${shownPath}.`,
   );
+}
+
+/** Packaged plugin path: install via the harness's own CLI, raw entry on failure. */
+async function packagedPluginSetup(
+  plugin: PackagedPlugin,
+  chosen: DetectedAgent,
+  options: WizardOptions,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+): Promise<void> {
+  const agentId = chosen.definition.id;
+  const agentName = chosen.definition.name;
+
+  // A pre-selected --agent means "just run it", same as the prompt-review
+  // bypass; otherwise ask before touching the user's harness config.
+  let install = true;
+  if (!options.agent) {
+    const answer = await p.confirm({
+      message: `Install the Subtext plugin in ${agentName}? ${pc.dim(`(${plugin.confirmHint})`)}`,
+    });
+    install = !p.isCancel(answer) && answer;
+  }
+  if (!install) {
+    onEvent('plugin_setup_declined', { agent: agentId });
+    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Install it later');
+    return;
+  }
+
+  if (options.mock) {
+    p.log.info(pc.dim('Mock mode: skipping the real plugin install.'));
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
+    return;
+  }
+
+  if (await plugin.alreadyInstalled()) {
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'already-installed' });
+    p.log.success(`Subtext plugin already installed in ${agentName}.`);
+    return;
+  }
+
+  p.log.step(`Installing the Subtext plugin in ${agentName}…`);
+  let installed = false;
+  try {
+    installed = await plugin.install();
+  } catch {
+    // fall through to the raw MCP server entry
+  }
+  if (installed) {
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'plugin-cli' });
+    p.log.success(
+      `Subtext plugin installed — available in your next ${agentName} session.`,
+    );
+    return;
+  }
+
+  p.log.warn('Plugin install failed — falling back to a raw MCP server entry (tools only).');
+  const target = configWrite(agentId, options.dir, options.region)!;
+  await applyConfigWrite(target, agentId, agentName, options, onEvent, 'config-write-fallback');
 }
 
 /**
@@ -329,12 +408,16 @@ export async function offerPluginSetup(
   const agentId = chosen === MANUAL_CHOICE ? MANUAL_CHOICE : chosen.definition.id;
   onEvent('plugin_setup_offered', { agent: agentId });
 
-  if (chosen !== MANUAL_CHOICE && agentId === 'claude-code' && chosen.binaryPath) {
-    await claudeCodePluginSetup(chosen, options, onEvent);
-    return;
+  if (chosen !== MANUAL_CHOICE) {
+    const plugin = packagedPlugin(chosen, options);
+    if (plugin) {
+      await packagedPluginSetup(plugin, chosen, options, onEvent);
+      return;
+    }
   }
 
-  const target = configWrite(agentId, options.dir, options.region);
+  const target =
+    chosen === MANUAL_CHOICE ? null : configWrite(agentId, options.dir, options.region);
   if (!target) {
     // Cursor (plugin route), Zed, Claude Desktop, manual.
     const lines =
@@ -349,8 +432,6 @@ export async function offerPluginSetup(
   const agentName = chosen === MANUAL_CHOICE ? 'your agent' : chosen.definition.name;
   const shownPath = prettyPath(target.file);
 
-  // A pre-selected --agent means "just run it", same as the prompt-review
-  // bypass; otherwise ask before touching a config file.
   let proceed = true;
   if (!options.agent) {
     const answer = await p.confirm({
@@ -372,24 +453,5 @@ export async function offerPluginSetup(
     return;
   }
 
-  let outcome: WriteOutcome;
-  try {
-    outcome = await target.write();
-  } catch {
-    outcome = 'unparseable';
-  }
-
-  if (outcome === 'unparseable') {
-    onEvent('plugin_setup_failed', { agent: agentId });
-    p.log.warn(`Could not update ${shownPath} — it may have a format we can't merge safely.`);
-    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Add it by hand');
-    return;
-  }
-
-  onEvent('plugin_setup_completed', { agent: agentId, method: 'config-write' });
-  p.log.success(
-    outcome === 'written'
-      ? `Subtext MCP server added to ${shownPath} — picked up the next time ${agentName} starts here.`
-      : `Subtext MCP server already configured in ${shownPath}.`,
-  );
+  await applyConfigWrite(target, agentId, agentName, options, onEvent, 'config-write');
 }

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -127,8 +127,9 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
       }
-      // Line-anchored so the header inside a comment or string doesn't count.
-      const headerRe = /^[ \t]*\[mcp_servers\.subtext\][ \t]*(?:#.*)?$/m;
+      // Line-anchored so the header inside a comment or string doesn't
+      // count; tolerates CRLF line endings.
+      const headerRe = /^[ \t]*\[mcp_servers\.subtext\][ \t]*(?:#.*)?\r?$/m;
       const headerMatch = headerRe.exec(existing);
       if (headerMatch) {
         const tableStart = headerMatch.index + headerMatch[0].length;

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -47,7 +47,8 @@ function indent(block: string): string[] {
 
 function prettyPath(file: string): string {
   const home = os.homedir();
-  return file.startsWith(home) ? `~${file.slice(home.length)}` : file;
+  if (file === home) return '~';
+  return file.startsWith(home + path.sep) ? `~${file.slice(home.length)}` : file;
 }
 
 // ---------------------------------------------------------------------------
@@ -336,8 +337,22 @@ function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): Packaged
           `claude plugin marketplace add ${PLUGIN_REPO_URL}`,
           `claude plugin install ${PLUGIN_SPEC}`,
         ],
-        // No cheap local check; `plugin install` handles re-runs itself.
-        alreadyInstalled: async () => false,
+        // `claude plugin install` records installs in installed_plugins.json,
+        // keyed by <plugin>@<marketplace> — the same spec we install.
+        alreadyInstalled: async () => {
+          try {
+            const installed = JSON.parse(
+              await fs.readFile(
+                path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json'),
+                'utf8',
+              ),
+            ) as { plugins?: Record<string, unknown> };
+            const entry = installed.plugins?.[PLUGIN_SPEC];
+            return Array.isArray(entry) && entry.length > 0;
+          } catch {
+            return false;
+          }
+        },
         install: () => installClaudeCodePlugin(binaryPath, options.dir),
       };
     case 'gemini':

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
+import { runTerminalAgent } from './agents/helpers.js';
 import { MANUAL_CHOICE } from './agents/index.js';
 import type { DetectedAgent } from './agents/types.js';
 import type { Region, WizardOptions } from './config.js';
@@ -10,20 +11,24 @@ import { subtextMcpUrl } from './config.js';
 
 /**
  * Post-install plugin setup. Once the coding agent has run (or been handed)
- * the install prompt, wire the Subtext MCP server into that same harness so
- * it can review captured sessions in later conversations.
+ * the install prompt, wire Subtext into that same harness so it can review
+ * captured sessions in later conversations.
  *
- * The wizard writes the server entry straight into the harness's own MCP
- * config file — no agent commands, no slash commands to paste. Harnesses
- * without a file we can safely edit (Zed, Claude Desktop, unknown) get
- * instructions instead, as do declines and unparseable configs.
+ * The packaged plugin is preferred wherever one exists, because it bundles
+ * the skills (proof, review, live…) on top of the MCP server: Claude Code
+ * installs it via its plugin CLI, Cursor via the official /add-plugin.
+ * Harnesses without a plugin get the raw MCP server entry written straight
+ * into their own config file — tools only, no agent commands involved.
+ * Harnesses without a file we can safely edit (Zed, Claude Desktop,
+ * unknown) get instructions instead, as do declines and unparseable
+ * configs.
  */
 
 export const PLUGIN_MARKETPLACE_URL = 'https://github.com/fullstorydev/subtext';
 export const PLUGIN_SPEC = 'subtext@subtext-marketplace';
 
 const WHY_PLUGIN =
-  'The Subtext MCP server gives your coding agent tools to replay and review the sessions you just set up capturing.';
+  'The Subtext plugin gives your coding agent tools and skills to replay and review the sessions you just set up capturing.';
 
 /** The generic MCP server entry, for harnesses without a specific format. */
 export function manualMcpConfig(region: Region): string {
@@ -115,7 +120,9 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
  * The MCP config file each harness reads, in its own format. Project-scoped
  * where the harness supports it (the server rides along with the repo);
  * user-global otherwise. Returns null when there's no file we can safely
- * edit — those harnesses get instructions.
+ * edit — those harnesses get instructions. Cursor is deliberately absent:
+ * its packaged plugin (/add-plugin subtext) is the primary route, so it
+ * goes through instructions rather than a config write.
  */
 function configWrite(agentId: string, dir: string, region: Region): ConfigWrite | null {
   const url = subtextMcpUrl(region);
@@ -123,8 +130,6 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
   switch (agentId) {
     case 'claude-code':
       return jsonConfigWrite(path.join(dir, '.mcp.json'), 'mcpServers', { type: 'http', url });
-    case 'cursor':
-      return jsonConfigWrite(path.join(dir, '.cursor', 'mcp.json'), 'mcpServers', { url });
     case 'vscode':
       return jsonConfigWrite(path.join(dir, '.vscode', 'mcp.json'), 'servers', {
         type: 'http',
@@ -157,13 +162,19 @@ function pluginInstructions(agentId: string, region: Region): string[] {
   switch (agentId) {
     case 'claude-code':
       return [
-        `Add this to .mcp.json in the project (or run /plugin install ${PLUGIN_SPEC}`,
-        `after /plugin marketplace add ${PLUGIN_MARKETPLACE_URL}):`,
+        'In a Claude Code session, run (installs tools + skills):',
+        `  /plugin marketplace add ${PLUGIN_MARKETPLACE_URL}`,
+        `  /plugin install ${PLUGIN_SPEC}`,
+        '',
+        'Prefer a raw MCP server (tools only)? Add this to .mcp.json in the project:',
         ...indent(manualMcpConfig(region)),
       ];
     case 'cursor':
       return [
-        'Add this to .cursor/mcp.json in the project (or run /add-plugin subtext in Cursor):',
+        'In Cursor, run this in the agent pane (installs tools + skills):',
+        '  /add-plugin subtext',
+        '',
+        'Prefer a raw MCP server (tools only)? Add this to .cursor/mcp.json in the project:',
         ...indent(JSON.stringify({ mcpServers: { subtext: { url } } }, null, 2)),
       ];
     case 'claude-desktop':
@@ -198,12 +209,15 @@ function pluginInstructions(agentId: string, region: Region): string[] {
 /** Shown when the user took the raw prompt — we don't know their harness. */
 function manualChoiceInstructions(region: Region): string[] {
   return [
-    'Claude Code — add to .mcp.json in the project:',
+    'Claude Code — run in a session (installs tools + skills):',
+    `  /plugin marketplace add ${PLUGIN_MARKETPLACE_URL}`,
+    `  /plugin install ${PLUGIN_SPEC}`,
+    '',
+    'Cursor — run in the agent pane (installs tools + skills):',
+    '  /add-plugin subtext',
+    '',
+    'Any other MCP-capable agent — add this server config (tools only):',
     ...indent(manualMcpConfig(region)),
-    '',
-    'Cursor — the same entry in .cursor/mcp.json (or run /add-plugin subtext).',
-    '',
-    'Any other MCP-capable agent — the same server URL in its MCP settings.',
   ];
 }
 
@@ -212,9 +226,100 @@ function manualChoiceInstructions(region: Region): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Step 8 of the wizard, after the prompt run: wire the Subtext MCP server
- * into the harness that ran the install. Never throws — the install already
- * succeeded, so config trouble is reported and the wizard finishes cleanly.
+ * Run `claude plugin marketplace add` + `claude plugin install`. The
+ * marketplace add is soft-fail (it errors when the marketplace is already
+ * registered, e.g. on a re-run); the install itself decides success.
+ */
+async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise<boolean> {
+  const addExit = await runTerminalAgent({
+    binaryPath,
+    args: ['plugin', 'marketplace', 'add', PLUGIN_MARKETPLACE_URL],
+    cwd,
+    stdout: 'inherit',
+  });
+  if (addExit !== 0) {
+    p.log.info(pc.dim('Marketplace add failed — it may already be registered; continuing.'));
+  }
+  const installExit = await runTerminalAgent({
+    binaryPath,
+    args: ['plugin', 'install', PLUGIN_SPEC],
+    cwd,
+    stdout: 'inherit',
+  });
+  return installExit === 0;
+}
+
+/**
+ * Claude Code path: the packaged plugin first — it carries the skills, not
+ * just the MCP tools — and the raw .mcp.json entry only if that fails.
+ */
+async function claudeCodePluginSetup(
+  chosen: DetectedAgent,
+  options: WizardOptions,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+): Promise<void> {
+  let install = true;
+  if (!options.agent) {
+    const answer = await p.confirm({
+      message: `Install the Subtext plugin in Claude Code? ${pc.dim(
+        '(session-review tools plus the proof/review skills)',
+      )}`,
+    });
+    install = !p.isCancel(answer) && answer;
+  }
+  if (!install) {
+    onEvent('plugin_setup_declined', { agent: 'claude-code' });
+    p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Install it later');
+    return;
+  }
+
+  if (options.mock) {
+    p.log.info(pc.dim('Mock mode: skipping the real plugin install.'));
+    onEvent('plugin_setup_completed', { agent: 'claude-code', method: 'mock' });
+    return;
+  }
+
+  p.log.step('Installing the Subtext plugin in Claude Code…');
+  let installed = false;
+  try {
+    installed = await installClaudeCodePlugin(chosen.binaryPath!, options.dir);
+  } catch {
+    // fall through to the raw MCP server entry
+  }
+  if (installed) {
+    onEvent('plugin_setup_completed', { agent: 'claude-code', method: 'plugin-cli' });
+    p.log.success(
+      'Subtext plugin installed — tools and skills are available in your next Claude Code session.',
+    );
+    return;
+  }
+
+  p.log.warn('Plugin install failed — falling back to a raw MCP server entry (tools only).');
+  const target = configWrite('claude-code', options.dir, options.region)!;
+  let outcome: WriteOutcome;
+  try {
+    outcome = await target.write();
+  } catch {
+    outcome = 'unparseable';
+  }
+  if (outcome === 'unparseable') {
+    onEvent('plugin_setup_failed', { agent: 'claude-code' });
+    p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Add it by hand');
+    return;
+  }
+  onEvent('plugin_setup_completed', { agent: 'claude-code', method: 'config-write-fallback' });
+  p.log.success(
+    outcome === 'written'
+      ? `Subtext MCP server added to ${prettyPath(target.file)} — picked up the next time Claude Code starts here.`
+      : `Subtext MCP server already configured in ${prettyPath(target.file)}.`,
+  );
+}
+
+/**
+ * Step 8 of the wizard, after the prompt run: wire Subtext into the harness
+ * that ran the install — packaged plugin where one exists, raw MCP server
+ * entry otherwise. Never throws — the install already succeeded, so plugin
+ * trouble is reported and the wizard finishes cleanly.
  */
 export async function offerPluginSetup(
   chosen: DetectedAgent | typeof MANUAL_CHOICE,
@@ -224,15 +329,20 @@ export async function offerPluginSetup(
   const agentId = chosen === MANUAL_CHOICE ? MANUAL_CHOICE : chosen.definition.id;
   onEvent('plugin_setup_offered', { agent: agentId });
 
+  if (chosen !== MANUAL_CHOICE && agentId === 'claude-code' && chosen.binaryPath) {
+    await claudeCodePluginSetup(chosen, options, onEvent);
+    return;
+  }
+
   const target = configWrite(agentId, options.dir, options.region);
   if (!target) {
-    // Zed, Claude Desktop, manual: no file we can safely edit.
+    // Cursor (plugin route), Zed, Claude Desktop, manual.
     const lines =
       chosen === MANUAL_CHOICE
         ? manualChoiceInstructions(options.region)
         : pluginInstructions(agentId, options.region);
     onEvent('plugin_setup_completed', { agent: agentId, method: 'instructions' });
-    p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext MCP server');
+    p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext plugin');
     return;
   }
 

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -478,6 +478,36 @@ async function removeSupersededRawEntry(
   }
 }
 
+/**
+ * Confirm gate for the plugin prompts. An explicit "No" is a decline —
+ * instructions for later. Ctrl+C / Escape skips the rest of the step
+ * with no further output: unlike the wizard's earlier prompts this is
+ * not a CancelledError, because by now the install itself has already
+ * succeeded and "nothing was changed" / exit 130 would misreport it.
+ */
+async function confirmOrSkip(
+  message: string,
+  agentId: string,
+  region: Region,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+  laterTitle: string,
+): Promise<boolean> {
+  const answer = await p.confirm({ message });
+  if (p.isCancel(answer)) {
+    onEvent('plugin_setup_declined', { agent: agentId, cancelled: true });
+    p.log.info(
+      pc.dim('Plugin setup skipped — run this installer again any time to set it up.'),
+    );
+    return false;
+  }
+  if (!answer) {
+    onEvent('plugin_setup_declined', { agent: agentId });
+    p.note(pluginInstructions(agentId, region).join('\n'), laterTitle);
+    return false;
+  }
+  return true;
+}
+
 /** Packaged plugin path: install via the harness's own CLI, raw entry on failure. */
 async function packagedPluginSetup(
   plugin: PackagedPlugin,
@@ -501,16 +531,16 @@ async function packagedPluginSetup(
 
   // A pre-selected --agent means "just run it", same as the prompt-review
   // bypass; otherwise ask before touching the user's harness config.
-  let install = true;
-  if (!options.agent) {
-    const answer = await p.confirm({
-      message: `Install the Subtext plugin in ${agentName}? ${pc.dim(`(${plugin.confirmHint})`)}`,
-    });
-    install = !p.isCancel(answer) && answer;
-  }
-  if (!install) {
-    onEvent('plugin_setup_declined', { agent: agentId });
-    p.note(pluginInstructions(agentId, region).join('\n'), 'Install it later');
+  if (
+    !options.agent &&
+    !(await confirmOrSkip(
+      `Install the Subtext plugin in ${agentName}? ${pc.dim(`(${plugin.confirmHint})`)}`,
+      agentId,
+      region,
+      onEvent,
+      'Install it later',
+    ))
+  ) {
     return;
   }
 
@@ -542,16 +572,16 @@ async function packagedPluginSetup(
   const target = configWrite(agentId, options.dir, region)!;
   // The user approved the plugin install, not a config-file edit — ask
   // again before touching a different file (same --agent bypass as above).
-  let fallback = true;
-  if (!options.agent) {
-    const answer = await p.confirm({
-      message: `Add the Subtext MCP server to ${prettyPath(target.file)} instead?`,
-    });
-    fallback = !p.isCancel(answer) && answer;
-  }
-  if (!fallback) {
-    onEvent('plugin_setup_declined', { agent: agentId });
-    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it later');
+  if (
+    !options.agent &&
+    !(await confirmOrSkip(
+      `Add the Subtext MCP server to ${prettyPath(target.file)} instead?`,
+      agentId,
+      region,
+      onEvent,
+      'Add it later',
+    ))
+  ) {
     return;
   }
   await applyConfigWrite(target, agentId, agentName, region, onEvent, 'config-write-fallback');
@@ -597,18 +627,18 @@ export async function offerPluginSetup(
   const agentName = chosen === MANUAL_CHOICE ? 'your agent' : chosen.definition.name;
   const shownPath = prettyPath(target.file);
 
-  let proceed = true;
-  if (!options.agent) {
-    const answer = await p.confirm({
-      message: `Add the Subtext MCP server to ${shownPath}? ${pc.dim(
+  if (
+    !options.agent &&
+    !(await confirmOrSkip(
+      `Add the Subtext MCP server to ${shownPath}? ${pc.dim(
         `(lets ${agentName} review captured sessions)`,
       )}`,
-    });
-    proceed = !p.isCancel(answer) && answer;
-  }
-  if (!proceed) {
-    onEvent('plugin_setup_declined', { agent: agentId });
-    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it later');
+      agentId,
+      region,
+      onEvent,
+      'Add it later',
+    ))
+  ) {
     return;
   }
 

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -1,0 +1,182 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { runTerminalAgent } from './agents/helpers.js';
+import { MANUAL_CHOICE } from './agents/index.js';
+import type { DetectedAgent } from './agents/types.js';
+import type { Region, WizardOptions } from './config.js';
+import { subtextMcpUrl } from './config.js';
+
+/**
+ * Post-install plugin setup. Once the coding agent has run (or been handed)
+ * the install prompt, wire the Subtext plugin / MCP server into that same
+ * harness so it can review captured sessions in later conversations.
+ *
+ * Claude Code is the only harness with a scriptable install (its `plugin`
+ * CLI subcommand); Cursor ships an official plugin behind a slash command;
+ * everything else gets its own manual MCP server config.
+ */
+
+export const PLUGIN_MARKETPLACE_URL = 'https://github.com/fullstorydev/subtext';
+export const PLUGIN_SPEC = 'subtext@subtext-marketplace';
+
+const CLAUDE_CODE_SLASH_COMMANDS = [
+  `/plugin marketplace add ${PLUGIN_MARKETPLACE_URL}`,
+  `/plugin install ${PLUGIN_SPEC}`,
+];
+
+const WHY_PLUGIN =
+  'The Subtext plugin gives your coding agent tools to replay and review the sessions you just set up capturing.';
+
+/** The generic MCP server entry, for harnesses without a packaged plugin. */
+export function manualMcpConfig(region: Region): string {
+  return JSON.stringify(
+    { mcpServers: { subtext: { type: 'http', url: subtextMcpUrl(region) } } },
+    null,
+    2,
+  );
+}
+
+function indent(block: string): string[] {
+  return block.split('\n').map((line) => `  ${line}`);
+}
+
+/** Harness-specific instructions for adding the plugin by hand. */
+function pluginInstructions(agentId: string, region: Region): string[] {
+  const url = subtextMcpUrl(region);
+  switch (agentId) {
+    case 'claude-code':
+      return ['In a Claude Code session, run:', ...CLAUDE_CODE_SLASH_COMMANDS.map((c) => `  ${c}`)];
+    case 'cursor':
+      return ['In Cursor, run this in the agent pane:', '  /add-plugin subtext'];
+    case 'claude-desktop':
+      return [
+        'In Claude Desktop: Settings → Connectors → Add custom connector,',
+        `then enter: ${url}`,
+      ];
+    case 'codex':
+      return [
+        'Add the Subtext MCP server to ~/.codex/config.toml:',
+        '  [mcp_servers.subtext]',
+        `  url = "${url}"`,
+      ];
+    case 'gemini':
+      return [
+        'Add the Subtext MCP server to ~/.gemini/settings.json:',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { httpUrl: url } } }, null, 2)),
+      ];
+    case 'vscode':
+      return [
+        'Add the Subtext MCP server to .vscode/mcp.json in this project:',
+        ...indent(JSON.stringify({ servers: { subtext: { type: 'http', url } } }, null, 2)),
+      ];
+    default:
+      // windsurf, zed, and anything we don't know: point at the harness's
+      // MCP settings with the generic server entry.
+      return [
+        `Add an MCP server named 'subtext' in your agent's MCP settings:`,
+        ...indent(manualMcpConfig(region)),
+      ];
+  }
+}
+
+/** Shown when the user took the raw prompt — we don't know their harness. */
+function manualChoiceInstructions(region: Region): string[] {
+  return [
+    'Claude Code — run in a session:',
+    ...CLAUDE_CODE_SLASH_COMMANDS.map((c) => `  ${c}`),
+    '',
+    'Cursor — run in the agent pane:',
+    '  /add-plugin subtext',
+    '',
+    'Any other MCP-capable agent — add this server config:',
+    ...indent(manualMcpConfig(region)),
+  ];
+}
+
+/**
+ * Run `claude plugin marketplace add` + `claude plugin install`. The
+ * marketplace add is soft-fail (it errors when the marketplace is already
+ * registered, e.g. on a re-run); the install itself decides success.
+ */
+async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise<boolean> {
+  const addExit = await runTerminalAgent({
+    binaryPath,
+    args: ['plugin', 'marketplace', 'add', PLUGIN_MARKETPLACE_URL],
+    cwd,
+    stdout: 'inherit',
+  });
+  if (addExit !== 0) {
+    p.log.info(pc.dim('Marketplace add failed — it may already be registered; continuing.'));
+  }
+  const installExit = await runTerminalAgent({
+    binaryPath,
+    args: ['plugin', 'install', PLUGIN_SPEC],
+    cwd,
+    stdout: 'inherit',
+  });
+  return installExit === 0;
+}
+
+/**
+ * Step 8 of the wizard, after the prompt run: set up the Subtext plugin in
+ * the harness that ran the install. Never throws for anything short of a
+ * user cancel elsewhere — the install already succeeded, so plugin trouble
+ * is reported and the wizard still finishes cleanly.
+ */
+export async function offerPluginSetup(
+  chosen: DetectedAgent | typeof MANUAL_CHOICE,
+  options: WizardOptions,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+): Promise<void> {
+  const agentId = chosen === MANUAL_CHOICE ? MANUAL_CHOICE : chosen.definition.id;
+  onEvent('plugin_setup_offered', { agent: agentId });
+
+  // Automated path: Claude Code has a plugin CLI we can drive directly.
+  if (chosen !== MANUAL_CHOICE && chosen.definition.id === 'claude-code' && chosen.binaryPath) {
+    // A pre-selected --agent means "just run it", same as the prompt-review
+    // bypass; otherwise ask before touching the user's Claude Code config.
+    let install = true;
+    if (!options.agent) {
+      const answer = await p.confirm({
+        message: `Install the Subtext plugin in Claude Code? ${pc.dim(
+          '(adds the subtext marketplace + plugin so it can review captured sessions)',
+        )}`,
+      });
+      install = !p.isCancel(answer) && answer;
+    }
+    if (!install) {
+      onEvent('plugin_setup_declined', { agent: agentId });
+      p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Install it later');
+      return;
+    }
+
+    if (options.mock) {
+      p.log.info(pc.dim('Mock mode: skipping the real plugin install.'));
+      onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
+      return;
+    }
+
+    p.log.step('Installing the Subtext plugin in Claude Code…');
+    try {
+      if (await installClaudeCodePlugin(chosen.binaryPath, options.dir)) {
+        onEvent('plugin_setup_completed', { agent: agentId, method: 'cli' });
+        p.log.success('Subtext plugin installed — Claude Code can review your sessions.');
+        return;
+      }
+    } catch {
+      // fall through to the manual instructions below
+    }
+    onEvent('plugin_setup_failed', { agent: agentId });
+    p.log.warn('Could not install the plugin automatically.');
+    p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Install it by hand');
+    return;
+  }
+
+  // Everyone else: precise instructions for their harness.
+  const lines =
+    chosen === MANUAL_CHOICE
+      ? manualChoiceInstructions(options.region)
+      : pluginInstructions(chosen.definition.id, options.region);
+  onEvent('plugin_setup_completed', { agent: agentId, method: 'instructions' });
+  p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext plugin');
+}

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -64,10 +64,15 @@ interface ConfigWrite {
 
 type JsonObject = Record<string, unknown>;
 
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * Merge `{ [section]: { subtext: entry } }` into a JSON config file,
  * creating the file (and parent dirs) if needed. Never clobbers a file it
- * can't parse — JSONC configs with comments fall back to instructions.
+ * can't parse or merge into — JSONC configs with comments, or files where
+ * the root or section isn't an object, fall back to instructions.
  */
 function jsonConfigWrite(
   file: string,
@@ -79,10 +84,13 @@ function jsonConfigWrite(
     async write() {
       let config: JsonObject = {};
       try {
-        config = JSON.parse(await fs.readFile(file, 'utf8')) as JsonObject;
+        const parsed: unknown = JSON.parse(await fs.readFile(file, 'utf8'));
+        if (!isPlainObject(parsed)) return 'unparseable';
+        config = parsed;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
       }
+      if (config[section] != null && !isPlainObject(config[section])) return 'unparseable';
       const servers = (config[section] ??= {}) as JsonObject;
       if (JSON.stringify(servers.subtext) === JSON.stringify(entry)) return 'unchanged';
       servers.subtext = entry;
@@ -142,12 +150,13 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
       return jsonConfigWrite(path.join(home, '.gemini', 'settings.json'), 'mcpServers', {
         httpUrl: url,
       });
-    case 'windsurf':
-      return jsonConfigWrite(
-        path.join(home, '.codeium', 'windsurf', 'mcp_config.json'),
-        'mcpServers',
-        { serverUrl: url },
-      );
+    case 'devin':
+      // Read by the Devin harness (Devin Desktop's local agent and the
+      // Devin CLI); project-scoped so the server rides along with the repo.
+      return jsonConfigWrite(path.join(dir, '.devin', 'config.json'), 'mcpServers', {
+        url,
+        transport: 'http',
+      });
     case 'codex':
       return codexConfigWrite(path.join(home, '.codex', 'config.toml'), url);
     default:
@@ -187,6 +196,16 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         '',
         'Prefer a raw MCP server? Add this to ~/.gemini/settings.json:',
         ...indent(JSON.stringify({ mcpServers: { subtext: { httpUrl: url } } }, null, 2)),
+      ];
+    case 'devin':
+      return [
+        'Add the Subtext MCP server with the Devin CLI:',
+        `  devin mcp add subtext ${url}`,
+        '',
+        'Or add this to .devin/config.json in this project:',
+        ...indent(
+          JSON.stringify({ mcpServers: { subtext: { url, transport: 'http' } } }, null, 2),
+        ),
       ];
     case 'claude-desktop':
       return [
@@ -319,7 +338,7 @@ async function applyConfigWrite(
   target: ConfigWrite,
   agentId: string,
   agentName: string,
-  options: WizardOptions,
+  region: Region,
   onEvent: (event: string, properties?: Record<string, unknown>) => void,
   method: string,
 ): Promise<void> {
@@ -333,7 +352,7 @@ async function applyConfigWrite(
   if (outcome === 'unparseable') {
     onEvent('plugin_setup_failed', { agent: agentId });
     p.log.warn(`Could not update ${shownPath} — it may have a format we can't merge safely.`);
-    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Add it by hand');
+    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it by hand');
     return;
   }
   onEvent('plugin_setup_completed', { agent: agentId, method });
@@ -348,6 +367,7 @@ async function applyConfigWrite(
 async function packagedPluginSetup(
   plugin: PackagedPlugin,
   chosen: DetectedAgent,
+  region: Region,
   options: WizardOptions,
   onEvent: (event: string, properties?: Record<string, unknown>) => void,
 ): Promise<void> {
@@ -365,7 +385,7 @@ async function packagedPluginSetup(
   }
   if (!install) {
     onEvent('plugin_setup_declined', { agent: agentId });
-    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Install it later');
+    p.note(pluginInstructions(agentId, region).join('\n'), 'Install it later');
     return;
   }
 
@@ -399,18 +419,21 @@ async function packagedPluginSetup(
   }
 
   p.log.warn('Plugin install failed — falling back to a raw MCP server entry (tools only).');
-  const target = configWrite(agentId, options.dir, options.region)!;
-  await applyConfigWrite(target, agentId, agentName, options, onEvent, 'config-write-fallback');
+  const target = configWrite(agentId, options.dir, region)!;
+  await applyConfigWrite(target, agentId, agentName, region, onEvent, 'config-write-fallback');
 }
 
 /**
  * Step 8 of the wizard, after the prompt run: wire Subtext into the harness
  * that ran the install — packaged plugin where one exists, raw MCP server
- * entry otherwise. Never throws — the install already succeeded, so plugin
- * trouble is reported and the wizard finishes cleanly.
+ * entry otherwise. `region` is the org's resolved realm (from the auth
+ * token), not the CLI flag — the MCP URLs written here must match the org.
+ * Never throws — the install already succeeded, so plugin trouble is
+ * reported and the wizard finishes cleanly.
  */
 export async function offerPluginSetup(
   chosen: DetectedAgent | typeof MANUAL_CHOICE,
+  region: Region,
   options: WizardOptions,
   onEvent: (event: string, properties?: Record<string, unknown>) => void,
 ): Promise<void> {
@@ -420,19 +443,18 @@ export async function offerPluginSetup(
   if (chosen !== MANUAL_CHOICE) {
     const plugin = packagedPlugin(chosen, options);
     if (plugin) {
-      await packagedPluginSetup(plugin, chosen, options, onEvent);
+      await packagedPluginSetup(plugin, chosen, region, options, onEvent);
       return;
     }
   }
 
-  const target =
-    chosen === MANUAL_CHOICE ? null : configWrite(agentId, options.dir, options.region);
+  const target = chosen === MANUAL_CHOICE ? null : configWrite(agentId, options.dir, region);
   if (!target) {
     // Cursor (plugin route), Zed, Claude Desktop, manual.
     const lines =
       chosen === MANUAL_CHOICE
-        ? manualChoiceInstructions(options.region)
-        : pluginInstructions(agentId, options.region);
+        ? manualChoiceInstructions(region)
+        : pluginInstructions(agentId, region);
     onEvent('plugin_setup_completed', { agent: agentId, method: 'instructions' });
     p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext plugin');
     return;
@@ -452,7 +474,7 @@ export async function offerPluginSetup(
   }
   if (!proceed) {
     onEvent('plugin_setup_declined', { agent: agentId });
-    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Add it later');
+    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it later');
     return;
   }
 
@@ -462,5 +484,5 @@ export async function offerPluginSetup(
     return;
   }
 
-  await applyConfigWrite(target, agentId, agentName, options, onEvent, 'config-write');
+  await applyConfigWrite(target, agentId, agentName, region, onEvent, 'config-write');
 }

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -151,12 +151,14 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
         httpUrl: url,
       });
     case 'devin':
-      // Read by the Devin harness (Devin Desktop's local agent and the
-      // Devin CLI); project-scoped so the server rides along with the repo.
-      return jsonConfigWrite(path.join(dir, '.devin', 'config.json'), 'mcpServers', {
-        url,
-        transport: 'http',
-      });
+      // Cascade — the panel the handoff points at — kept Windsurf's config
+      // file through the Devin rebrand; .devin/config.json is the separate
+      // Devin CLI harness (see pluginInstructions).
+      return jsonConfigWrite(
+        path.join(home, '.codeium', 'windsurf', 'mcp_config.json'),
+        'mcpServers',
+        { serverUrl: url },
+      );
     case 'codex':
       return codexConfigWrite(path.join(home, '.codex', 'config.toml'), url);
     default:
@@ -199,13 +201,11 @@ function pluginInstructions(agentId: string, region: Region): string[] {
       ];
     case 'devin':
       return [
-        'Add the Subtext MCP server with the Devin CLI:',
-        `  devin mcp add subtext ${url}`,
+        'Add this to ~/.codeium/windsurf/mcp_config.json (read by Cascade in Devin Desktop):',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { serverUrl: url } } }, null, 2)),
         '',
-        'Or add this to .devin/config.json in this project:',
-        ...indent(
-          JSON.stringify({ mcpServers: { subtext: { url, transport: 'http' } } }, null, 2),
-        ),
+        'Using the Devin CLI harness instead? Run:',
+        `  devin mcp add subtext ${url}`,
       ];
     case 'claude-desktop':
       return [

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -410,6 +410,15 @@ async function packagedPluginSetup(
   const agentId = chosen.definition.id;
   const agentName = chosen.definition.name;
 
+  // Check for an existing install before asking anything — a re-run
+  // shouldn't prompt for (or count a decline against) a plugin that's
+  // already there. Skipped in mock mode, which never reads real state.
+  if (!options.mock && (await plugin.alreadyInstalled())) {
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'already-installed' });
+    p.log.success(`Subtext plugin already installed in ${agentName}.`);
+    return;
+  }
+
   // A pre-selected --agent means "just run it", same as the prompt-review
   // bypass; otherwise ask before touching the user's harness config.
   let install = true;
@@ -430,12 +439,6 @@ async function packagedPluginSetup(
       pc.dim(`Mock mode: would run\n  ${plugin.commands.join('\n  ')}`),
     );
     onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
-    return;
-  }
-
-  if (await plugin.alreadyInstalled()) {
-    onEvent('plugin_setup_completed', { agent: agentId, method: 'already-installed' });
-    p.log.success(`Subtext plugin already installed in ${agentName}.`);
     return;
   }
 

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -1,6 +1,8 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
-import { runTerminalAgent } from './agents/helpers.js';
 import { MANUAL_CHOICE } from './agents/index.js';
 import type { DetectedAgent } from './agents/types.js';
 import type { Region, WizardOptions } from './config.js';
@@ -8,26 +10,22 @@ import { subtextMcpUrl } from './config.js';
 
 /**
  * Post-install plugin setup. Once the coding agent has run (or been handed)
- * the install prompt, wire the Subtext plugin / MCP server into that same
- * harness so it can review captured sessions in later conversations.
+ * the install prompt, wire the Subtext MCP server into that same harness so
+ * it can review captured sessions in later conversations.
  *
- * Claude Code is the only harness with a scriptable install (its `plugin`
- * CLI subcommand); Cursor ships an official plugin behind a slash command;
- * everything else gets its own manual MCP server config.
+ * The wizard writes the server entry straight into the harness's own MCP
+ * config file — no agent commands, no slash commands to paste. Harnesses
+ * without a file we can safely edit (Zed, Claude Desktop, unknown) get
+ * instructions instead, as do declines and unparseable configs.
  */
 
 export const PLUGIN_MARKETPLACE_URL = 'https://github.com/fullstorydev/subtext';
 export const PLUGIN_SPEC = 'subtext@subtext-marketplace';
 
-const CLAUDE_CODE_SLASH_COMMANDS = [
-  `/plugin marketplace add ${PLUGIN_MARKETPLACE_URL}`,
-  `/plugin install ${PLUGIN_SPEC}`,
-];
-
 const WHY_PLUGIN =
-  'The Subtext plugin gives your coding agent tools to replay and review the sessions you just set up capturing.';
+  'The Subtext MCP server gives your coding agent tools to replay and review the sessions you just set up capturing.';
 
-/** The generic MCP server entry, for harnesses without a packaged plugin. */
+/** The generic MCP server entry, for harnesses without a specific format. */
 export function manualMcpConfig(region: Region): string {
   return JSON.stringify(
     { mcpServers: { subtext: { type: 'http', url: subtextMcpUrl(region) } } },
@@ -40,14 +38,134 @@ function indent(block: string): string[] {
   return block.split('\n').map((line) => `  ${line}`);
 }
 
-/** Harness-specific instructions for adding the plugin by hand. */
+function prettyPath(file: string): string {
+  const home = os.homedir();
+  return file.startsWith(home) ? `~${file.slice(home.length)}` : file;
+}
+
+// ---------------------------------------------------------------------------
+// Direct config writes
+// ---------------------------------------------------------------------------
+
+type WriteOutcome = 'written' | 'unchanged' | 'unparseable';
+
+interface ConfigWrite {
+  /** Config file the server entry goes into. */
+  file: string;
+  write(): Promise<WriteOutcome>;
+}
+
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Merge `{ [section]: { subtext: entry } }` into a JSON config file,
+ * creating the file (and parent dirs) if needed. Never clobbers a file it
+ * can't parse — JSONC configs with comments fall back to instructions.
+ */
+function jsonConfigWrite(
+  file: string,
+  section: string,
+  entry: JsonObject,
+): ConfigWrite {
+  return {
+    file,
+    async write() {
+      let config: JsonObject = {};
+      try {
+        config = JSON.parse(await fs.readFile(file, 'utf8')) as JsonObject;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
+      }
+      const servers = (config[section] ??= {}) as JsonObject;
+      if (JSON.stringify(servers.subtext) === JSON.stringify(entry)) return 'unchanged';
+      servers.subtext = entry;
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+      return 'written';
+    },
+  };
+}
+
+/**
+ * Codex config is TOML, which we don't parse — append the server table if
+ * it isn't there yet, and leave an existing one alone.
+ */
+function codexConfigWrite(file: string, url: string): ConfigWrite {
+  return {
+    file,
+    async write() {
+      let existing = '';
+      try {
+        existing = await fs.readFile(file, 'utf8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
+      }
+      if (existing.includes('[mcp_servers.subtext]')) return 'unchanged';
+      const block = `${existing && !existing.endsWith('\n') ? '\n' : ''}${
+        existing ? '\n' : ''
+      }[mcp_servers.subtext]\nurl = "${url}"\n`;
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, existing + block, 'utf8');
+      return 'written';
+    },
+  };
+}
+
+/**
+ * The MCP config file each harness reads, in its own format. Project-scoped
+ * where the harness supports it (the server rides along with the repo);
+ * user-global otherwise. Returns null when there's no file we can safely
+ * edit — those harnesses get instructions.
+ */
+function configWrite(agentId: string, dir: string, region: Region): ConfigWrite | null {
+  const url = subtextMcpUrl(region);
+  const home = os.homedir();
+  switch (agentId) {
+    case 'claude-code':
+      return jsonConfigWrite(path.join(dir, '.mcp.json'), 'mcpServers', { type: 'http', url });
+    case 'cursor':
+      return jsonConfigWrite(path.join(dir, '.cursor', 'mcp.json'), 'mcpServers', { url });
+    case 'vscode':
+      return jsonConfigWrite(path.join(dir, '.vscode', 'mcp.json'), 'servers', {
+        type: 'http',
+        url,
+      });
+    case 'gemini':
+      return jsonConfigWrite(path.join(home, '.gemini', 'settings.json'), 'mcpServers', {
+        httpUrl: url,
+      });
+    case 'windsurf':
+      return jsonConfigWrite(
+        path.join(home, '.codeium', 'windsurf', 'mcp_config.json'),
+        'mcpServers',
+        { serverUrl: url },
+      );
+    case 'codex':
+      return codexConfigWrite(path.join(home, '.codex', 'config.toml'), url);
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Instruction fallbacks
+// ---------------------------------------------------------------------------
+
+/** Harness-specific instructions for adding the server by hand. */
 function pluginInstructions(agentId: string, region: Region): string[] {
   const url = subtextMcpUrl(region);
   switch (agentId) {
     case 'claude-code':
-      return ['In a Claude Code session, run:', ...CLAUDE_CODE_SLASH_COMMANDS.map((c) => `  ${c}`)];
+      return [
+        `Add this to .mcp.json in the project (or run /plugin install ${PLUGIN_SPEC}`,
+        `after /plugin marketplace add ${PLUGIN_MARKETPLACE_URL}):`,
+        ...indent(manualMcpConfig(region)),
+      ];
     case 'cursor':
-      return ['In Cursor, run this in the agent pane:', '  /add-plugin subtext'];
+      return [
+        'Add this to .cursor/mcp.json in the project (or run /add-plugin subtext in Cursor):',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { url } } }, null, 2)),
+      ];
     case 'claude-desktop':
       return [
         'In Claude Desktop: Settings → Connectors → Add custom connector,',
@@ -70,8 +188,6 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         ...indent(JSON.stringify({ servers: { subtext: { type: 'http', url } } }, null, 2)),
       ];
     default:
-      // windsurf, zed, and anything we don't know: point at the harness's
-      // MCP settings with the generic server entry.
       return [
         `Add an MCP server named 'subtext' in your agent's MCP settings:`,
         ...indent(manualMcpConfig(region)),
@@ -82,46 +198,23 @@ function pluginInstructions(agentId: string, region: Region): string[] {
 /** Shown when the user took the raw prompt — we don't know their harness. */
 function manualChoiceInstructions(region: Region): string[] {
   return [
-    'Claude Code — run in a session:',
-    ...CLAUDE_CODE_SLASH_COMMANDS.map((c) => `  ${c}`),
-    '',
-    'Cursor — run in the agent pane:',
-    '  /add-plugin subtext',
-    '',
-    'Any other MCP-capable agent — add this server config:',
+    'Claude Code — add to .mcp.json in the project:',
     ...indent(manualMcpConfig(region)),
+    '',
+    'Cursor — the same entry in .cursor/mcp.json (or run /add-plugin subtext).',
+    '',
+    'Any other MCP-capable agent — the same server URL in its MCP settings.',
   ];
 }
 
-/**
- * Run `claude plugin marketplace add` + `claude plugin install`. The
- * marketplace add is soft-fail (it errors when the marketplace is already
- * registered, e.g. on a re-run); the install itself decides success.
- */
-async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise<boolean> {
-  const addExit = await runTerminalAgent({
-    binaryPath,
-    args: ['plugin', 'marketplace', 'add', PLUGIN_MARKETPLACE_URL],
-    cwd,
-    stdout: 'inherit',
-  });
-  if (addExit !== 0) {
-    p.log.info(pc.dim('Marketplace add failed — it may already be registered; continuing.'));
-  }
-  const installExit = await runTerminalAgent({
-    binaryPath,
-    args: ['plugin', 'install', PLUGIN_SPEC],
-    cwd,
-    stdout: 'inherit',
-  });
-  return installExit === 0;
-}
+// ---------------------------------------------------------------------------
+// The wizard step
+// ---------------------------------------------------------------------------
 
 /**
- * Step 8 of the wizard, after the prompt run: set up the Subtext plugin in
- * the harness that ran the install. Never throws for anything short of a
- * user cancel elsewhere — the install already succeeded, so plugin trouble
- * is reported and the wizard still finishes cleanly.
+ * Step 8 of the wizard, after the prompt run: wire the Subtext MCP server
+ * into the harness that ran the install. Never throws — the install already
+ * succeeded, so config trouble is reported and the wizard finishes cleanly.
  */
 export async function offerPluginSetup(
   chosen: DetectedAgent | typeof MANUAL_CHOICE,
@@ -131,52 +224,62 @@ export async function offerPluginSetup(
   const agentId = chosen === MANUAL_CHOICE ? MANUAL_CHOICE : chosen.definition.id;
   onEvent('plugin_setup_offered', { agent: agentId });
 
-  // Automated path: Claude Code has a plugin CLI we can drive directly.
-  if (chosen !== MANUAL_CHOICE && chosen.definition.id === 'claude-code' && chosen.binaryPath) {
-    // A pre-selected --agent means "just run it", same as the prompt-review
-    // bypass; otherwise ask before touching the user's Claude Code config.
-    let install = true;
-    if (!options.agent) {
-      const answer = await p.confirm({
-        message: `Install the Subtext plugin in Claude Code? ${pc.dim(
-          '(adds the subtext marketplace + plugin so it can review captured sessions)',
-        )}`,
-      });
-      install = !p.isCancel(answer) && answer;
-    }
-    if (!install) {
-      onEvent('plugin_setup_declined', { agent: agentId });
-      p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Install it later');
-      return;
-    }
-
-    if (options.mock) {
-      p.log.info(pc.dim('Mock mode: skipping the real plugin install.'));
-      onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
-      return;
-    }
-
-    p.log.step('Installing the Subtext plugin in Claude Code…');
-    try {
-      if (await installClaudeCodePlugin(chosen.binaryPath, options.dir)) {
-        onEvent('plugin_setup_completed', { agent: agentId, method: 'cli' });
-        p.log.success('Subtext plugin installed — Claude Code can review your sessions.');
-        return;
-      }
-    } catch {
-      // fall through to the manual instructions below
-    }
-    onEvent('plugin_setup_failed', { agent: agentId });
-    p.log.warn('Could not install the plugin automatically.');
-    p.note(pluginInstructions('claude-code', options.region).join('\n'), 'Install it by hand');
+  const target = configWrite(agentId, options.dir, options.region);
+  if (!target) {
+    // Zed, Claude Desktop, manual: no file we can safely edit.
+    const lines =
+      chosen === MANUAL_CHOICE
+        ? manualChoiceInstructions(options.region)
+        : pluginInstructions(agentId, options.region);
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'instructions' });
+    p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext MCP server');
     return;
   }
 
-  // Everyone else: precise instructions for their harness.
-  const lines =
-    chosen === MANUAL_CHOICE
-      ? manualChoiceInstructions(options.region)
-      : pluginInstructions(chosen.definition.id, options.region);
-  onEvent('plugin_setup_completed', { agent: agentId, method: 'instructions' });
-  p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext plugin');
+  const agentName = chosen === MANUAL_CHOICE ? 'your agent' : chosen.definition.name;
+  const shownPath = prettyPath(target.file);
+
+  // A pre-selected --agent means "just run it", same as the prompt-review
+  // bypass; otherwise ask before touching a config file.
+  let proceed = true;
+  if (!options.agent) {
+    const answer = await p.confirm({
+      message: `Add the Subtext MCP server to ${shownPath}? ${pc.dim(
+        `(lets ${agentName} review captured sessions)`,
+      )}`,
+    });
+    proceed = !p.isCancel(answer) && answer;
+  }
+  if (!proceed) {
+    onEvent('plugin_setup_declined', { agent: agentId });
+    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Add it later');
+    return;
+  }
+
+  if (options.mock) {
+    p.log.info(pc.dim(`Mock mode: would add the Subtext MCP server to ${shownPath}.`));
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
+    return;
+  }
+
+  let outcome: WriteOutcome;
+  try {
+    outcome = await target.write();
+  } catch {
+    outcome = 'unparseable';
+  }
+
+  if (outcome === 'unparseable') {
+    onEvent('plugin_setup_failed', { agent: agentId });
+    p.log.warn(`Could not update ${shownPath} — it may have a format we can't merge safely.`);
+    p.note(pluginInstructions(agentId, options.region).join('\n'), 'Add it by hand');
+    return;
+  }
+
+  onEvent('plugin_setup_completed', { agent: agentId, method: 'config-write' });
+  p.log.success(
+    outcome === 'written'
+      ? `Subtext MCP server added to ${shownPath} — picked up the next time ${agentName} starts here.`
+      : `Subtext MCP server already configured in ${shownPath}.`,
+  );
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,7 +117,7 @@ export async function runWizard(options: WizardOptions): Promise<number> {
         console.log(`\n${prompt}\n`);
       }
       // 8. Plugin setup — we don't know the harness, so show every path.
-      await offerPluginSetup(MANUAL_CHOICE, options, (event, properties) =>
+      await offerPluginSetup(MANUAL_CHOICE, auth.region, options, (event, properties) =>
         telemetry.capture(event, properties),
       );
       p.outro('Run this installer again any time with: npx @subtext/install');
@@ -164,12 +164,12 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     //    Skipped when the agent run failed: fix the install first.
     if (result.mode === 'handoff') {
       p.note(result.followUp?.join('\n') ?? '', 'Next steps');
-      await offerPluginSetup(chosen, options, (event, properties) =>
+      await offerPluginSetup(chosen, auth.region, options, (event, properties) =>
         telemetry.capture(event, properties),
       );
       p.outro('Finish the install in your agent — it will guide you from here.');
     } else if (result.exitCode === 0) {
-      await offerPluginSetup(chosen, options, (event, properties) =>
+      await offerPluginSetup(chosen, auth.region, options, (event, properties) =>
         telemetry.capture(event, properties),
       );
       p.outro(

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,6 +7,7 @@ import type { WizardOptions } from './config.js';
 import { WIZARD_VERSION } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
+import { offerPluginSetup } from './pluginSetup.js';
 import { buildInstallPrompt } from './prompt/build.js';
 import { offerPromptReview } from './promptReview.js';
 import { fetchCaptureSnippet } from './snippet.js';
@@ -114,6 +115,10 @@ export async function runWizard(options: WizardOptions): Promise<number> {
         p.log.warn('Could not write to the clipboard — copy the prompt below.');
         console.log(`\n${prompt}\n`);
       }
+      // 8. Plugin setup — we don't know the harness, so show every path.
+      await offerPluginSetup(MANUAL_CHOICE, options, (event, properties) =>
+        telemetry.capture(event, properties),
+      );
       p.outro('Run this installer again any time with: npx @subtext/install');
       await telemetry.flush();
       return 0;
@@ -138,10 +143,19 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       exit_code: result.exitCode ?? null,
     });
 
+    // 8. Plugin setup — install the Subtext plugin in the harness that ran
+    //    (or will run) the prompt, so it can review sessions afterwards.
+    //    Skipped when the agent run failed: fix the install first.
     if (result.mode === 'handoff') {
       p.note(result.followUp?.join('\n') ?? '', 'Next steps');
+      await offerPluginSetup(chosen, options, (event, properties) =>
+        telemetry.capture(event, properties),
+      );
       p.outro('Finish the install in your agent — it will guide you from here.');
     } else if (result.exitCode === 0) {
+      await offerPluginSetup(chosen, options, (event, properties) =>
+        telemetry.capture(event, properties),
+      );
       p.outro(
         'Subtext install finished. Review the changes (and subtext-setup-report.md), then deploy to start capturing sessions.',
       );

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,6 +3,7 @@ import clipboard from 'clipboardy';
 import pc from 'picocolors';
 import { authenticate } from './auth.js';
 import { chooseAgent, detectAgents, MANUAL_CHOICE } from './agents/index.js';
+import type { LaunchResult } from './agents/types.js';
 import type { WizardOptions } from './config.js';
 import { WIZARD_VERSION } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
@@ -129,13 +130,28 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       kind: chosen.definition.kind,
     });
 
-    const result = await chosen.definition.launch({
-      prompt,
-      cwd: options.dir,
-      binaryPath: chosen.binaryPath,
-      debug: options.debug,
-      onEvent: (event, properties) => telemetry.capture(event, properties),
-    });
+    // Mock mode stops short of the real run — no agent launched, no app
+    // opened — but pretends it succeeded so the rest of the flow (plugin
+    // setup, outro) can be previewed.
+    let result: LaunchResult;
+    if (options.mock) {
+      p.log.warn(`Mock mode: skipping the real ${chosen.definition.name} run.`);
+      result =
+        chosen.definition.kind === 'terminal'
+          ? { mode: 'ran', exitCode: 0 }
+          : {
+              mode: 'handoff',
+              followUp: [`(mock) ${chosen.definition.name} would open with the prompt on your clipboard.`],
+            };
+    } else {
+      result = await chosen.definition.launch({
+        prompt,
+        cwd: options.dir,
+        binaryPath: chosen.binaryPath,
+        debug: options.debug,
+        onEvent: (event, properties) => telemetry.capture(event, properties),
+      });
+    }
 
     telemetry.capture('wizard_completed', {
       agent: chosen.definition.id,


### PR DESCRIPTION
## What

Adds step 8 to the wizard: after the install prompt runs (or is handed off), wire Subtext into the same harness that ran it, so that agent can review captured sessions in later conversations. Stacked on #1.

The packaged plugin is the primary route wherever one exists — it bundles the skills (proof, review, live…) on top of the MCP tools. Harnesses without a plugin get the raw MCP server entry written directly into their own config file, pointing at the realm-aware `…/mcp/subtext` endpoint.

| Harness | Primary | Fallback |
|---|---|---|
| Claude Code | plugin CLI: `claude plugin marketplace add …/fullstorydev/subtext` + `claude plugin install subtext@subtext-marketplace` | write `.mcp.json` (project) |
| Cursor | instructions: `/add-plugin subtext` (official plugin) | `.cursor/mcp.json` shown in the same note |
| Gemini CLI | `gemini extensions install …/fullstorydev/subtext` (repo carries `gemini-extension.json`) | write `~/.gemini/settings.json` (`{url, type: http}`) |
| VS Code | write `.vscode/mcp.json` (project) | instructions |
| Devin Desktop | write `~/.codeium/windsurf/mcp_config.json` (read by Cascade) | instructions (incl. `devin mcp add` for the Devin CLI) |
| Codex CLI | append `[mcp_servers.subtext]` to `~/.codex/config.toml` (updates `url` in an existing table) | instructions |
| Zed / Claude Desktop / manual | instructions only | — |

## Behavior notes

- Confirm-gated before touching any config, with the same "just run it" bypass as the prompt review when `--agent` is pre-selected.
- JSON config writes merge (sibling servers and extra fields on an existing `subtext` entry preserved) and are idempotent on re-run; a file that fails to parse — or whose root/section isn't an object — is never clobbered: falls back to printed instructions. A failed packaged install asks again before the fallback config write; once a packaged install succeeds (or is detected, scope-aware for Claude Code), a raw fallback entry from an earlier run is removed (matched by its Subtext endpoint URL).
- Gemini checks `~/.gemini/extensions/subtext` up front so a re-run doesn't fall back into writing a duplicate raw server entry next to the extension.
- Skipped when the agent run exits non-zero; never fails the wizard — plugin trouble degrades to instructions.
- Region-aware: EU orgs get `api.eu1.fullstory.com/mcp/subtext` in raw entries (the packaged installs carry both realms via the plugin itself).
- New telemetry events: `plugin_setup_offered` / `completed` (method: `plugin-cli` / `already-installed` / `config-write` / `config-write-fallback` / `instructions` / `mock`) / `declined` (`cancelled: true` when the prompt was cancelled rather than answered) / `failed`.

## Testing

- `npm run typecheck` / `build` clean.
- Exercised all config writers against a temp project + fake `$HOME`: fresh files, merges into existing configs, idempotent re-runs, corrupt-file fallback.
- Exercised packaged installs with fake `claude`/`gemini` binaries: success, failure→fallback write, and already-installed paths.
- Not verified live: a real `claude plugin install` / `gemini extensions install` against the actual plugin repo (didn't want to mutate global agent config from the dev machine), and whether `gemini extensions install` prompts for consent interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The wizard can modify user-global and project agent config files and invoke `claude`/`gemini` plugin CLIs, though merges are conservative and failures degrade to instructions without aborting setup.
> 
> **Overview**
> Adds **wizard step 8** after the install prompt runs or is handed off: `offerPluginSetup` wires Subtext into the same harness so it can review captured sessions later. Packaged plugins are preferred (**Claude Code** marketplace install, **Gemini** extension CLI); other agents get merged **MCP server** entries in harness-specific configs (`.mcp.json`, `.vscode/mcp.json`, `~/.gemini/settings.json`, Devin Cascade `mcp_config.json`, Codex TOML) or printed instructions (Cursor `/add-plugin`, Zed, Claude Desktop). Confirm prompts apply unless `--agent` is set; unparseable JSON is never overwritten; successful plugin installs remove duplicate raw entries by URL; the step is skipped when the agent exits non-zero and does not fail the wizard.
> 
> **Windsurf** is renamed to **Devin Desktop** (`devin` id, `devin-desktop` CLI). **`subtextMcpUrl`** centralizes realm-aware MCP URLs (from auth org realm, not `--region`). **`--mock`** now fakes a successful agent run and logs plugin actions instead of mutating configs or running CLIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308ece2a3fa381cc6b3441586ff45e82bebee1ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




