### PR TITLE
Add telemetry and redo plugin / prompt ordering for gui agent harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Consent-gated and fire-and-forget: after login the wizard asks whether it may co
 
 Two layers:
 
-- **CLI events** (`src/telemetry.ts`) — a `start` event when a terminal or manual run reaches handoff (harness, time-to-handoff), plus a `fail`/`skipped` outcome if the run errors, is cancelled, or a terminal agent exits nonzero.
-- **Agent-side checkpoints** — the prompt instructs the agent to report each install step (`precheck` → `complete`) as it finishes; `analytics_providers` reflects what the agent actually detects, not the user's picker selection. Two variants:
-  - *Terminal runs* `curl` the endpoint directly, authenticated via a `SUBTEXT_TELEMETRY_TOKEN` env var the wizard sets on the child process.
+- **CLI events** (`src/telemetry.ts`) — a `start` event when a terminal or manual run reaches handoff (harness, time-to-handoff), a `complete` outcome when a terminal agent exits (`success` requires the agent's own install-step marker, not just exit code 0), and a `fail`/`skipped` outcome if the run errors or is cancelled.
+- **Agent-side checkpoints** — the prompt instructs the agent to report each install step as it finishes; `analytics_providers` reflects what the agent actually detects, not the user's picker selection. Two variants:
+  - *Terminal runs* never see a credential — the token would leak to every install subprocess (npm postinstall scripts etc.). Instead the agent **prints** one `__SUBTEXT_TELEMETRY__ {…}` marker line per step (`precheck` → `mask_pii`); the wizard parses these out of the agent's stdout (`src/agents/telemetry-marker.ts`, with a step/metadata allowlist and one-event-per-step cap) and sends the events itself with the token it holds in-process.
   - *GUI handoffs* log through the Subtext plugin's `telemetry-event` MCP tool — the wizard walks the user through installing the plugin (fullstorydev/subtext) before opening the app — and the agent logs its own `start` event with harness/model.
-  - *Manual handoffs* get no checkpoints: embedding the user's token in a clipboard prompt isn't safe, and there's no known agent to hold the plugin.
+  - *Manual handoffs* (and `--print-prompt` output) get no checkpoints: there's no wizard attached to parse markers and no known agent to hold the plugin.
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,25 @@ Terminal agents get the **headless** prompt variant (approval gates replaced wit
 
 ## Telemetry
 
-Two layers, both fire-and-forget and disabled by `--no-telemetry`:
+Consent-gated and fire-and-forget: after login the wizard asks whether it may collect telemetry about the install session (step progress, outcomes, and timings — never code or data). Declining, or passing `--no-telemetry`, disables everything below. Events are `WorkflowEvent` payloads (workflow `onboard`) POSTed to `/subtext/telemetry`, authenticated with the user's OAuth access token.
 
-- **CLI events** (`src/telemetry.ts`) — `wizard_started`, `auth_completed`, `integrations_selected`, `agents_detected`, `agent_launch_started`, `wizard_completed`, `wizard_error`, correlated by a per-run `run_id`.
-- **Agent-side checkpoints** — the prompt itself instructs the agent to `curl` a background ping after each install step, tagged with the same `run_id`, so progress is visible even during the agent-led portion.
+Two layers:
+
+- **CLI events** (`src/telemetry.ts`) — a `start` event when a terminal or manual run reaches handoff (harness, time-to-handoff), plus a `fail`/`skipped` outcome if the run errors, is cancelled, or a terminal agent exits nonzero.
+- **Agent-side checkpoints** — the prompt instructs the agent to report each install step (`precheck` → `complete`) as it finishes; `analytics_providers` reflects what the agent actually detects, not the user's picker selection. Two variants:
+  - *Terminal runs* `curl` the endpoint directly, authenticated via a `SUBTEXT_TELEMETRY_TOKEN` env var the wizard sets on the child process.
+  - *GUI handoffs* log through the Subtext plugin's `telemetry-event` MCP tool — the wizard walks the user through installing the plugin (fullstorydev/subtext) before opening the app — and the agent logs its own `start` event with harness/model.
+  - *Manual handoffs* get no checkpoints: embedding the user's token in a clipboard prompt isn't safe, and there's no known agent to hold the plugin.
 
 ## Endpoints
 
-Auth and snippet use **real production endpoints**:
+Auth, snippet, and telemetry use **real production endpoints**:
 
 - `https://auth.fullstory.com/oauth/{register,authorize,token}` — OAuth 2.1, PKCE public client, loopback redirect
 - `https://api.fullstory.com/code/v2/snippet?org=…&type=CORE` — public org snippet (`api.eu1.…` for EU orgs)
-- `https://telemetry.subtext.fullstory.com/v1/wizard-events` — **PLACEHOLDER**, no backend yet
+- `https://api.fullstory.com/subtext/telemetry` — workflow-event ingest (Bearer auth, realm-aware)
 
-Overridable via env vars (`SUBTEXT_AUTH_BASE_URL`, `SUBTEXT_API_BASE_URL`, `SUBTEXT_TELEMETRY_URL`, `SUBTEXT_OAUTH_CLIENT_ID`, `SUBTEXT_OAUTH_SCOPES`). Use `--mock` to run the whole flow offline with canned auth and the example snippet. Remaining backend work: pre-registered OAuth client, scope decision, telemetry ingest, org-aware snippet for custom-host orgs.
+Overridable via env vars (`SUBTEXT_AUTH_BASE_URL`, `SUBTEXT_API_BASE_URL`, `SUBTEXT_TELEMETRY_URL`, `SUBTEXT_OAUTH_CLIENT_ID`, `SUBTEXT_OAUTH_SCOPES`). Use `--mock` to run the whole flow offline with canned auth and the example snippet. Remaining backend work: pre-registered OAuth client, scope decision, org-aware snippet for custom-host orgs.
 
 ## Flags
 

--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -67,6 +67,7 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
     ],
     cwd: ctx.cwd,
     promptOnStdin: ctx.prompt,
+    env: ctx.env,
     stdout: 'pipe',
     onStdoutLine: (line) => {
       let event: StreamEvent;

--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -3,17 +3,17 @@ import path from 'node:path';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { firstExistingPath, runTerminalAgent, which } from './helpers.js';
+import { extractTelemetryMarkers } from './telemetry-marker.js';
 import type { AgentDefinition, LaunchContext, LaunchResult } from './types.js';
 
 /**
- * Tools the headless run is pre-authorized to use beyond edits:
- * docs fetching, dependency installs, and the background telemetry curls
- * the prompt asks for. Everything else falls back to Claude Code's own
- * permission rules.
+ * Tools the headless run is pre-authorized to use beyond edits: docs fetching
+ * and dependency installs. Telemetry needs no tool here — the agent just prints
+ * markers to stdout that the wizard parses. Everything else falls back to
+ * Claude Code's own permission rules.
  */
 const ALLOWED_TOOLS = [
   'WebFetch',
-  'Bash(curl:*)',
   'Bash(npm install:*)',
   'Bash(pnpm add:*)',
   'Bash(yarn add:*)',
@@ -67,9 +67,9 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
     ],
     cwd: ctx.cwd,
     promptOnStdin: ctx.prompt,
-    env: ctx.env,
     stdout: 'pipe',
     onStdoutLine: (line) => {
+      if (!line.trim()) return;
       let event: StreamEvent;
       try {
         event = JSON.parse(line) as StreamEvent;
@@ -80,7 +80,10 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
       if (event.type === 'assistant') {
         for (const block of event.message?.content ?? []) {
           if (block.type === 'text' && block.text?.trim()) {
-            console.log(pc.dim(block.text.trim()));
+            // The prompt has the agent print telemetry markers as plain text;
+            // pull them out of the stream and display only the rest.
+            const text = extractTelemetryMarkers(block.text, ctx.onTelemetry).trim();
+            if (text) console.log(pc.dim(text));
           } else if (block.type === 'tool_use') {
             console.log(pc.dim(`  → ${describeToolUse(block.name, block.input)}`));
             ctx.onEvent?.('agent_tool_use', { tool: block.name });
@@ -93,7 +96,11 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
   });
 
   if (resultText) {
-    p.note(resultText, 'Claude Code result');
+    // The result event duplicates the final assistant message, so any marker
+    // lines already stripped from the streamed display would resurface here.
+    // Strip them again; re-reported markers are deduped by the caller.
+    const cleaned = extractTelemetryMarkers(resultText, ctx.onTelemetry).trim();
+    if (cleaned) p.note(cleaned, 'Claude Code result');
   }
   return { mode: 'ran', exitCode };
 }

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -13,6 +13,7 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
     binaryPath: ctx.binaryPath!,
     args: ['exec', '--full-auto', ctx.prompt],
     cwd: ctx.cwd,
+    env: ctx.env,
     stdout: 'inherit',
   });
   return { mode: 'ran', exitCode };

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -1,6 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { runTerminalAgent, which } from './helpers.js';
+import { makeMarkerLineFilter } from './telemetry-marker.js';
 import type { AgentDefinition, LaunchContext, LaunchResult } from './types.js';
 
 async function launch(ctx: LaunchContext): Promise<LaunchResult> {
@@ -9,12 +10,14 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
 
   // `codex exec` is Codex's non-interactive mode; --full-auto lets it edit
   // files and run commands inside its workspace sandbox without prompting.
+  // We pipe stdout (rather than inherit) so the wizard can pull telemetry
+  // markers out of the stream; every other line is echoed through unchanged.
   const exitCode = await runTerminalAgent({
     binaryPath: ctx.binaryPath!,
     args: ['exec', '--full-auto', ctx.prompt],
     cwd: ctx.cwd,
-    env: ctx.env,
-    stdout: 'inherit',
+    stdout: 'pipe',
+    onStdoutLine: makeMarkerLineFilter(ctx.onTelemetry),
   });
   return { mode: 'ran', exitCode };
 }

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -1,19 +1,22 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { runTerminalAgent, which } from './helpers.js';
+import { makeMarkerLineFilter } from './telemetry-marker.js';
 import type { AgentDefinition, LaunchContext, LaunchResult } from './types.js';
 
 async function launch(ctx: LaunchContext): Promise<LaunchResult> {
   p.log.step('Running the Subtext install with Gemini CLI…');
   p.log.info(pc.dim('Gemini is doing the install in this terminal. Progress below.'));
 
-  // -p runs non-interactively; --yolo auto-approves tool calls.
+  // -p runs non-interactively; --yolo auto-approves tool calls. We pipe stdout
+  // (rather than inherit) so the wizard can pull telemetry markers out of the
+  // stream; every other line is echoed through unchanged.
   const exitCode = await runTerminalAgent({
     binaryPath: ctx.binaryPath!,
     args: ['--yolo', '-p', ctx.prompt],
     cwd: ctx.cwd,
-    env: ctx.env,
-    stdout: 'inherit',
+    stdout: 'pipe',
+    onStdoutLine: makeMarkerLineFilter(ctx.onTelemetry),
   });
   return { mode: 'ran', exitCode };
 }

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -12,6 +12,7 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
     binaryPath: ctx.binaryPath!,
     args: ['--yolo', '-p', ctx.prompt],
     cwd: ctx.cwd,
+    env: ctx.env,
     stdout: 'inherit',
   });
   return { mode: 'ran', exitCode };

--- a/src/agents/helpers.ts
+++ b/src/agents/helpers.ts
@@ -74,8 +74,6 @@ export function runTerminalAgent(opts: {
   args: string[];
   cwd: string;
   promptOnStdin?: string;
-  /** Extra environment variables merged over the wizard's own. */
-  env?: Record<string, string>;
   /** 'inherit' streams the agent's own output; 'pipe' lets the caller parse it. */
   stdout?: 'inherit' | 'pipe';
   onStdoutLine?: (line: string) => void;
@@ -83,7 +81,6 @@ export function runTerminalAgent(opts: {
   return new Promise((resolve, reject) => {
     const child = spawn(opts.binaryPath, opts.args, {
       cwd: opts.cwd,
-      env: opts.env ? { ...process.env, ...opts.env } : undefined,
       stdio: [
         opts.promptOnStdin !== undefined ? 'pipe' : 'inherit',
         opts.stdout ?? 'inherit',
@@ -99,14 +96,23 @@ export function runTerminalAgent(opts: {
     if (opts.stdout === 'pipe' && child.stdout && opts.onStdoutLine) {
       let buffer = '';
       child.stdout.setEncoding('utf8');
+      // Blank lines are delivered too — callers that echo the stream back to
+      // the terminal need them to preserve the agent's output formatting.
       child.stdout.on('data', (chunk: string) => {
         buffer += chunk;
         let newline;
         while ((newline = buffer.indexOf('\n')) !== -1) {
           const line = buffer.slice(0, newline);
           buffer = buffer.slice(newline + 1);
-          if (line.trim()) opts.onStdoutLine!(line);
+          opts.onStdoutLine!(line);
         }
+      });
+      // Flush whatever follows the last newline once the stream ends — the
+      // agent's final line (often its closing summary or last telemetry
+      // marker) can arrive without a trailing '\n' and must not be dropped.
+      child.stdout.on('end', () => {
+        if (buffer) opts.onStdoutLine!(buffer);
+        buffer = '';
       });
     }
 

--- a/src/agents/helpers.ts
+++ b/src/agents/helpers.ts
@@ -74,6 +74,8 @@ export function runTerminalAgent(opts: {
   args: string[];
   cwd: string;
   promptOnStdin?: string;
+  /** Extra environment variables merged over the wizard's own. */
+  env?: Record<string, string>;
   /** 'inherit' streams the agent's own output; 'pipe' lets the caller parse it. */
   stdout?: 'inherit' | 'pipe';
   onStdoutLine?: (line: string) => void;
@@ -81,6 +83,7 @@ export function runTerminalAgent(opts: {
   return new Promise((resolve, reject) => {
     const child = spawn(opts.binaryPath, opts.args, {
       cwd: opts.cwd,
+      env: opts.env ? { ...process.env, ...opts.env } : undefined,
       stdio: [
         opts.promptOnStdin !== undefined ? 'pipe' : 'inherit',
         opts.stdout ?? 'inherit',

--- a/src/agents/telemetry-marker.ts
+++ b/src/agents/telemetry-marker.ts
@@ -1,0 +1,153 @@
+import type { WorkflowEventMetadata, WorkflowOutcome, WorkflowStep } from '../telemetry.js';
+
+/**
+ * How terminal agents report per-step telemetry WITHOUT ever touching a
+ * credential: the prompt tells the agent to print marker lines to stdout, and
+ * the wizard — which alone holds the OAuth token — parses them out of the
+ * agent's output stream and sends the real WorkflowEvents itself. Nothing the
+ * agent (or any install subprocess it spawns) can read carries the token.
+ *
+ * The stream is untrusted: the agent echoes output of arbitrary repo code
+ * (install scripts, README contents), so everything a marker carries is
+ * validated against an allowlist before it can reach the authenticated
+ * telemetry endpoint.
+ */
+export const TELEMETRY_MARKER_PREFIX = '__SUBTEXT_TELEMETRY__';
+
+/** Steps a terminal agent may self-report. `start` and `complete` are the
+ * funnel bookends the wizard owns — excluded at the type level so no marker
+ * producer can ever emit one. */
+export type AgentWorkflowStep = Exclude<WorkflowStep, 'start' | 'complete'>;
+
+const AGENT_STEPS: ReadonlySet<string> = new Set<AgentWorkflowStep>([
+  'precheck',
+  'explore',
+  'plan',
+  'install',
+  'identify',
+  'link_analytics',
+  'mask_pii',
+]);
+
+const OUTCOMES: ReadonlySet<string> = new Set<WorkflowOutcome>([
+  'success',
+  'partial',
+  'fail',
+  'skipped',
+]);
+
+/** Per-field allowlist for marker metadata — the agent-reportable subset of
+ * WorkflowEventMetadata (telemetry.ts) with its expected type. `harness` and
+ * `model` are deliberately absent: the wizard stamps harness itself, so a
+ * forged marker can never override attribution. Unknown keys and wrong-typed
+ * values are dropped, strings and arrays are capped. */
+const METADATA_FIELDS: Record<string, 'boolean' | 'number' | 'string' | 'string[]'> = {
+  duration_ms: 'number',
+  tokens: 'number',
+  already_installed: 'boolean',
+  framework: 'string',
+  csp_present: 'boolean',
+  approved: 'boolean',
+  csp_modified: 'boolean',
+  identity_added: 'boolean',
+  analytics_providers: 'string[]',
+  masked_count: 'number',
+  privacy_check: 'boolean',
+};
+const MAX_STRING_LENGTH = 128;
+const MAX_ARRAY_LENGTH = 32;
+
+function sanitizeMetadata(raw: unknown): WorkflowEventMetadata | undefined {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined;
+  const source = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, kind] of Object.entries(METADATA_FIELDS)) {
+    const value = source[key];
+    if (value === undefined) continue;
+    if (kind === 'boolean' && typeof value === 'boolean') {
+      out[key] = value;
+    } else if (kind === 'number' && typeof value === 'number' && Number.isFinite(value)) {
+      out[key] = value;
+    } else if (kind === 'string' && typeof value === 'string') {
+      out[key] = value.slice(0, MAX_STRING_LENGTH);
+    } else if (kind === 'string[]' && Array.isArray(value)) {
+      out[key] = value
+        .filter((item): item is string => typeof item === 'string')
+        .slice(0, MAX_ARRAY_LENGTH)
+        .map((item) => item.slice(0, MAX_STRING_LENGTH));
+    }
+  }
+  return Object.keys(out).length > 0 ? (out as WorkflowEventMetadata) : undefined;
+}
+
+export interface StepMarker {
+  step: AgentWorkflowStep;
+  outcome?: WorkflowOutcome;
+  metadata?: WorkflowEventMetadata;
+}
+
+/**
+ * Parse one line of agent output into a telemetry step, or null if it is not a
+ * (valid, allowed) marker. Tolerates junk on both sides: indexOf finds the
+ * prefix behind timestamps/ANSI/log gutters, and the payload is taken from the
+ * first '{' to the last '}' so a marker wrapped in backticks or ending in
+ * punctuation still parses. Unknown steps/outcomes, malformed JSON, and
+ * disallowed metadata are dropped silently — telemetry must never disrupt the
+ * install.
+ */
+export function parseTelemetryMarker(line: string): StepMarker | null {
+  const at = line.indexOf(TELEMETRY_MARKER_PREFIX);
+  if (at === -1) return null;
+  const rest = line.slice(at + TELEMETRY_MARKER_PREFIX.length);
+  const open = rest.indexOf('{');
+  const close = rest.lastIndexOf('}');
+  if (open === -1 || close <= open) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rest.slice(open, close + 1));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.step !== 'string' || !AGENT_STEPS.has(obj.step)) return null;
+  const outcome =
+    typeof obj.outcome === 'string' && OUTCOMES.has(obj.outcome)
+      ? (obj.outcome as WorkflowOutcome)
+      : undefined;
+  return { step: obj.step as AgentWorkflowStep, outcome, metadata: sanitizeMetadata(obj.metadata) };
+}
+
+/**
+ * onStdoutLine handler for terminal agents whose raw output is piped through
+ * the wizard (codex, gemini): consume marker lines, echo everything else to
+ * the user's terminal unchanged.
+ */
+export function makeMarkerLineFilter(
+  onMarker?: (marker: StepMarker) => void,
+): (line: string) => void {
+  return (line) => {
+    const marker = parseTelemetryMarker(line);
+    if (marker) onMarker?.(marker);
+    else process.stdout.write(`${line}\n`);
+  };
+}
+
+/**
+ * Remove marker lines from a block of text (claude-code assistant blocks and
+ * its final result note), reporting each parsed marker. Returns the text with
+ * marker lines removed.
+ */
+export function extractTelemetryMarkers(
+  text: string,
+  onMarker?: (marker: StepMarker) => void,
+): string {
+  if (!text.includes(TELEMETRY_MARKER_PREFIX)) return text;
+  const kept: string[] = [];
+  for (const line of text.split('\n')) {
+    const marker = parseTelemetryMarker(line);
+    if (marker) onMarker?.(marker);
+    else kept.push(line);
+  }
+  return kept.join('\n');
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -14,6 +14,9 @@ export interface LaunchContext {
   cwd: string;
   binaryPath?: string;
   debug: boolean;
+  /** Extra environment for terminal launches (e.g. the telemetry token the
+   * prompt's checkpoint curls authenticate with). */
+  env?: Record<string, string>;
   onEvent?: (event: string, properties?: Record<string, unknown>) => void;
 }
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,3 +1,5 @@
+import type { StepMarker } from './telemetry-marker.js';
+
 export type AgentKind = 'terminal' | 'app';
 
 export interface DetectedAgent {
@@ -14,10 +16,11 @@ export interface LaunchContext {
   cwd: string;
   binaryPath?: string;
   debug: boolean;
-  /** Extra environment for terminal launches (e.g. the telemetry token the
-   * prompt's checkpoint curls authenticate with). */
-  env?: Record<string, string>;
   onEvent?: (event: string, properties?: Record<string, unknown>) => void;
+  /** Per-step telemetry the wizard parses out of the terminal agent's stdout
+   * (see telemetry-marker.ts). The agent never holds a credential — it only
+   * prints markers; the wizard sends the events with its own token. */
+  onTelemetry?: (marker: StepMarker) => void;
 }
 
 export interface LaunchResult {

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,7 @@ export const SNIPPET_PATH = '/code/v2/snippet';
  * protojson `WorkflowEvent` and requires an authenticated session — we send
  * the user's OAuth access token as `Authorization: Bearer`.
  */
-export const TELEMETRY_PATH = '/subtext/telemetry';
+const TELEMETRY_PATH = '/subtext/telemetry';
 
 export function telemetryUrl(region: Region): string {
   if (process.env.SUBTEXT_TELEMETRY_URL) return process.env.SUBTEXT_TELEMETRY_URL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@
  * snippet service). Anything still marked PLACEHOLDER has no backend yet.
  */
 
-export const WIZARD_VERSION = '0.1.1';
+export const WIZARD_VERSION = '0.1.2';
 
 export type Region = 'us' | 'eu';
 
@@ -53,11 +53,17 @@ export const OAUTH_SCOPES = process.env.SUBTEXT_OAUTH_SCOPES ?? 'sessions:read';
  * returns the full inline snippet body for a <script> tag. */
 export const SNIPPET_PATH = '/code/v2/snippet';
 
-/** Telemetry ingestion endpoint, fire-and-forget. PLACEHOLDER — no backend
- * exists yet; see plan doc. */
-export const TELEMETRY_ENDPOINT =
-  process.env.SUBTEXT_TELEMETRY_URL ??
-  'https://telemetry.subtext.fullstory.com/v1/wizard-events';
+/**
+ * Telemetry ingestion endpoint (lidar, fronted by gangplank). Accepts a
+ * protojson `WorkflowEvent` and requires an authenticated session — we send
+ * the user's OAuth access token as `Authorization: Bearer`.
+ */
+export const TELEMETRY_PATH = '/subtext/telemetry';
+
+export function telemetryUrl(region: Region): string {
+  if (process.env.SUBTEXT_TELEMETRY_URL) return process.env.SUBTEXT_TELEMETRY_URL;
+  return `${apiBaseUrl(region)}${TELEMETRY_PATH}`;
+}
 
 export const AUTH_CALLBACK_TIMEOUT_MS = 5 * 60_000;
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,55 @@
+import * as p from '@clack/prompts';
+import type { DetectedAgent } from './agents/types.js';
+import { apiBaseUrl, type Region } from './config.js';
+import { CancelledError } from './integrations.js';
+
+/** Remote MCP server bundled with the Subtext plugin (fullstorydev/subtext).
+ * HTTP only — no local process required. */
+export function subtextMcpUrl(region: Region): string {
+  return `${apiBaseUrl(region)}/mcp/subtext`;
+}
+
+/** Per-agent install steps, following the fullstorydev/subtext README. Agents
+ * without a store listing get the manual openskills + MCP-config path. */
+function instructions(agentId: string, agentName: string, mcpUrl: string): string {
+  switch (agentId) {
+    case 'cursor':
+      return [
+        'In Cursor, open the plugin Marketplace panel and install “Subtext”',
+        '(or add the fullstorydev/subtext repo as a marketplace).',
+      ].join('\n');
+    case 'claude-desktop':
+      return [
+        'In Claude Desktop, open Settings → Connectors → “Add custom connector”',
+        `and add the Subtext MCP server:\n${mcpUrl}`,
+      ].join('\n');
+    default:
+      return [
+        'Install the Subtext skills:  npx openskills install fullstorydev/subtext',
+        `Then add the subtext MCP server to ${agentName}'s MCP settings:\n${mcpUrl}`,
+      ].join('\n');
+  }
+}
+
+/**
+ * Walk the user through installing the Subtext plugin in their GUI agent
+ * before we hand off. The plugin gives the agent Subtext's skills and MCP
+ * tools — including `telemetry-event`, which the handoff prompt's telemetry
+ * section relies on. Declining is fine: the install prompt treats a missing
+ * tool as "skip telemetry silently".
+ */
+export async function guidePluginSetup(agent: DetectedAgent, region: Region): Promise<boolean> {
+  const name = agent.definition.name;
+  p.log.step(
+    `First, set up the Subtext plugin in ${name} — it gives the agent Subtext's skills and MCP tools.`,
+  );
+  p.note(instructions(agent.definition.id, name, subtextMcpUrl(region)), 'Subtext plugin setup');
+  const done = await p.confirm({
+    message: `Is the Subtext plugin set up in ${name}? ("No" continues without it — the install still works.)`,
+  });
+  if (p.isCancel(done)) throw new CancelledError();
+  if (!done) {
+    p.log.info('Continuing without the plugin — the agent will skip anything that needs it.');
+  }
+  return done;
+}

--- a/src/prompt/build.ts
+++ b/src/prompt/build.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { TELEMETRY_MARKER_PREFIX } from '../agents/telemetry-marker.js';
 import type { IntegrationSelection } from '../integrations.js';
 import { packageRootPath } from '../paths.js';
 
@@ -6,14 +7,15 @@ export type PromptMode = 'headless' | 'interactive';
 
 /**
  * How the prompt instructs the agent to report telemetry:
- * - 'curl'  — headless terminal runs; the wizard hands the agent an auth
- *   token via env and it POSTs WorkflowEvents directly.
- * - 'mcp'   — GUI handoffs, where the wizard just guided the Subtext plugin
- *   setup; the agent logs through the `telemetry-event` MCP tool.
- * - 'none'  — telemetry declined/disabled, or an unknown agent (manual
- *   handoff) with no safe way to authenticate.
+ * - 'mcp'    — GUI handoffs where the Subtext plugin is set up; the agent logs
+ *   through the `telemetry-event` MCP tool.
+ * - 'stdout' — terminal runs; the agent PRINTS per-step markers to stdout that
+ *   the wizard parses and sends with its own token. The agent never holds a
+ *   credential, so a malicious install subprocess has nothing to steal.
+ * - 'none'   — telemetry declined/disabled, a GUI handoff without the plugin,
+ *   or a manual handoff. The wizard reports what it can (start/complete) itself.
  */
-export type PromptTelemetry = 'curl' | 'mcp' | 'none';
+export type PromptTelemetry = 'mcp' | 'stdout' | 'none';
 
 export interface BuildPromptInput {
   /** Org-specific capture snippet HTML fetched from the API. */
@@ -21,8 +23,6 @@ export interface BuildPromptInput {
   selection: IntegrationSelection;
   mode: PromptMode;
   telemetry: PromptTelemetry;
-  /** Realm-aware /subtext/telemetry endpoint the curl checkpoints POST to. */
-  telemetryUrl: string;
 }
 
 const HEADLESS_MODE_SECTION = `## Mode: autonomous (headless)
@@ -32,6 +32,24 @@ You are running non-interactively inside the Subtext setup CLI. The user cannot 
 const INTERACTIVE_MODE_SECTION = `## Mode: interactive
 
 Work through the steps with the user in this conversation, honoring every approval gate below.`;
+
+/** Step/metadata table shared by both telemetry sections, so the two
+ * transports can never drift. Steps 1–7 are agent-reportable over either
+ * transport; the Step 8 `complete` row is MCP-only (for terminal runs the
+ * wizard owns `complete` itself). Keep field names in sync with
+ * WorkflowEventMetadata (telemetry.ts) and the allowlist in
+ * telemetry-marker.ts. */
+const STEP_TABLE = `| After | \`step\` | \`metadata\` fields |
+|-------|---------|--------------------|
+| Step 1 | \`precheck\` | \`already_installed\` (bool) |
+| Step 2 | \`explore\` | \`framework\` (string), \`csp_present\` (bool) |
+| Step 3 | \`plan\` | \`approved\` (bool) |
+| Step 4 | \`install\` | \`framework\` (string), \`csp_modified\` (bool) |
+| Step 5 | \`identify\` | \`identity_added\` (bool) |
+| Step 6 | \`link_analytics\` | \`analytics_providers\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
+| Step 7 | \`mask_pii\` | \`masked_count\` (int), \`privacy_check\` (bool) |`;
+
+const COMPLETE_ROW = `| Step 8 | \`complete\` | \`total_duration_ms\` (int), \`total_tokens\` (int) |`;
 
 /**
  * GUI-handoff variant: the agent logs milestones through the Subtext
@@ -46,47 +64,36 @@ The user already agreed, during Subtext setup, that this install may log anonymo
 
 Log one event before Step 1 — \`workflow="onboard" step="start"\` with \`harness\` (your coding tool) and \`model\` metadata — then one event as each of Steps 1–8 completes, with an \`outcome\` (\`success\`, \`partial\`, \`fail\`, or \`skipped\`) and that step's metadata fields:
 
-| After | Log step | Extra metadata |
-|-------|----------|----------------|
-| Step 1 | \`precheck\` | \`already_installed\` (bool) |
-| Step 2 | \`explore\` | \`framework\` (string), \`csp_present\` (bool) |
-| Step 3 | \`plan\` | \`approved\` (bool) |
-| Step 4 | \`install\` | \`framework\` (string), \`csp_modified\` (bool) |
-| Step 5 | \`identify\` | \`identity_added\` (bool) |
-| Step 6 | \`link_analytics\` | \`analytics_providers\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
-| Step 7 | \`mask_pii\` | \`masked_count\` (int), \`privacy_check\` (bool) |
-| Step 8 | \`complete\` | \`total_duration_ms\` (int), \`total_tokens\` (int) |
+${STEP_TABLE}
+${COMPLETE_ROW}
 
 Every event's metadata may also include \`duration_ms\` (int) and \`tokens\` (int) for that step when you can estimate them. Log each event at the moment the step finishes — not retroactively at the end — so durations and failure points are real. Metadata is a JSON object containing only these derived fields: never include file contents, code, secrets, or user data. Telemetry is fire-and-forget: if the tool is unavailable (e.g. the plugin isn't installed) or a call returns \`{"logged": false}\`, skip it silently and keep working — never block, retry, or abort the install because of telemetry. Do not announce telemetry calls to the user or mention them in your summaries.`;
 }
 
-function curlTelemetrySection(telemetryUrl: string): string {
-  return `## Telemetry checkpoints
+/**
+ * Terminal-run variant: the agent reports progress by PRINTING marker lines to
+ * stdout. The wizard (which holds the auth token) parses them out of the output
+ * stream and sends the real events — the agent is never handed a credential, so
+ * an install subprocess it spawns has nothing to exfiltrate. The wizard owns
+ * the `start` and `complete` bookends itself, so this section covers only the
+ * intermediate steps.
+ */
+function stdoutTelemetrySection(): string {
+  return `## Telemetry
 
-As you finish each step below, fire a non-blocking background telemetry ping so setup progress is visible to the Subtext team. The \`SUBTEXT_TELEMETRY_TOKEN\` environment variable is already set in your environment:
+The user already agreed, during Subtext setup, that this install may log anonymous progress telemetry — step outcomes and timings, never code or data. Do not ask again, and do not run any command or make any network request for telemetry.
 
-\`\`\`sh
-curl -s -X POST '${telemetryUrl}' \\
-  -H "Authorization: Bearer $SUBTEXT_TELEMETRY_TOKEN" \\
-  -H 'Content-Type: application/json' \\
-  -d '{"workflow":"onboard","step":"<step>","outcome":"<outcome>","metadata":<metadata>}' \\
-  > /dev/null 2>&1 &
+Instead, as each of Steps 1–7 completes, PRINT a single line to stdout in exactly this format (nothing else on the line):
+
+\`\`\`
+${TELEMETRY_MARKER_PREFIX} {"step":"<step>","outcome":"<outcome>","metadata":<metadata>}
 \`\`\`
 
-Fire one after each of Steps 1–8, with \`step\` and \`metadata\` per this table. \`outcome\` is \`success\`, \`partial\`, \`fail\`, or \`skipped\`, describing how that step went. In \`metadata\`, omit any field you don't know, and always include \`"duration_ms"\` (wall-clock milliseconds you spent on the step) when you can estimate it.
+\`outcome\` is one of \`success\`, \`partial\`, \`fail\`, or \`skipped\`. The wizard reads these lines from your output and reports them; it also records the overall start and completion, so do NOT print markers for those. Use these steps and metadata fields:
 
-| After  | \`step\` | \`metadata\` fields |
-|--------|----------|--------------------|
-| Step 1 | \`precheck\` | \`"already_installed"\` (bool) |
-| Step 2 | \`explore\` | \`"framework"\` (e.g. "next"), \`"csp_present"\` (bool) |
-| Step 3 | \`plan\` | \`"approved"\` (bool) |
-| Step 4 | \`install\` | \`"framework"\` (e.g. "next"), \`"csp_modified"\` (bool) |
-| Step 5 | \`identify\` | \`"identity_added"\` (bool) |
-| Step 6 | \`link_analytics\` | \`"analytics_providers"\` (array of SDK names found) |
-| Step 7 | \`mask_pii\` | \`"masked_count"\` (number), \`"privacy_check"\` (bool) |
-| Step 8 | \`complete\` | \`"total_duration_ms"\`, \`"total_tokens"\` (whole-flow totals) |
+${STEP_TABLE}
 
-Telemetry must never block or delay the install — if \`curl\` is unavailable, the variable is empty, or the request fails, skip silently and move on.`;
+\`metadata\` is a compact JSON object; it may also include \`duration_ms\` (int) for that step when you can estimate it. Omit any field you don't know (use \`{}\` if none apply). Never include file contents, code, secrets, or user data. Print each marker at the moment the step finishes — not retroactively — so failure points are real. Telemetry is best-effort: if you can't determine a step's outcome, just skip its marker and keep working. Do not mention these markers in your report or summaries.`;
 }
 
 function integrationsSection(selection: IntegrationSelection): string {
@@ -147,10 +154,10 @@ export function buildInstallPrompt(input: BuildPromptInput): string {
   const replacements: Record<string, string> = {
     MODE_SECTION: headless ? HEADLESS_MODE_SECTION : INTERACTIVE_MODE_SECTION,
     TELEMETRY_SECTION:
-      input.telemetry === 'curl'
-        ? curlTelemetrySection(input.telemetryUrl)
-        : input.telemetry === 'mcp'
-          ? mcpTelemetrySection()
+      input.telemetry === 'mcp'
+        ? mcpTelemetrySection()
+        : input.telemetry === 'stdout'
+          ? stdoutTelemetrySection()
           : '',
     INTEGRATIONS_SECTION: integrationsSection(input.selection),
     SNIPPET: input.snippet,

--- a/src/prompt/build.ts
+++ b/src/prompt/build.ts
@@ -48,16 +48,16 @@ Log one event before Step 1 — \`workflow="onboard" step="start"\` with \`harne
 
 | After | Log step | Extra metadata |
 |-------|----------|----------------|
-| Step 1 | \`precheck\` | \`alreadyInstalled\` (bool) |
-| Step 2 | \`explore\` | \`framework\` (string), \`cspPresent\` (bool) |
+| Step 1 | \`precheck\` | \`already_installed\` (bool) |
+| Step 2 | \`explore\` | \`framework\` (string), \`csp_present\` (bool) |
 | Step 3 | \`plan\` | \`approved\` (bool) |
-| Step 4 | \`install\` | \`framework\` (string), \`cspModified\` (bool) |
-| Step 5 | \`identify\` | \`identityAdded\` (bool) |
-| Step 6 | \`link_analytics\` | \`analyticsProviders\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
-| Step 7 | \`mask_pii\` | \`maskedCount\` (int), \`privacyCheck\` (bool) |
-| Step 8 | \`complete\` | \`totalDurationMs\` (int), \`totalTokens\` (int) |
+| Step 4 | \`install\` | \`framework\` (string), \`csp_modified\` (bool) |
+| Step 5 | \`identify\` | \`identity_added\` (bool) |
+| Step 6 | \`link_analytics\` | \`analytics_providers\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
+| Step 7 | \`mask_pii\` | \`masked_count\` (int), \`privacy_check\` (bool) |
+| Step 8 | \`complete\` | \`total_duration_ms\` (int), \`total_tokens\` (int) |
 
-Every event's metadata may also include \`durationMs\` (int) and \`tokens\` (int) for that step when you can estimate them. Log each event at the moment the step finishes — not retroactively at the end — so durations and failure points are real. Metadata is a JSON object containing only these derived fields: never include file contents, code, secrets, or user data. Telemetry is fire-and-forget: if the tool is unavailable (e.g. the plugin isn't installed) or a call returns \`{"logged": false}\`, skip it silently and keep working — never block, retry, or abort the install because of telemetry. Do not announce telemetry calls to the user or mention them in your summaries.`;
+Every event's metadata may also include \`duration_ms\` (int) and \`tokens\` (int) for that step when you can estimate them. Log each event at the moment the step finishes — not retroactively at the end — so durations and failure points are real. Metadata is a JSON object containing only these derived fields: never include file contents, code, secrets, or user data. Telemetry is fire-and-forget: if the tool is unavailable (e.g. the plugin isn't installed) or a call returns \`{"logged": false}\`, skip it silently and keep working — never block, retry, or abort the install because of telemetry. Do not announce telemetry calls to the user or mention them in your summaries.`;
 }
 
 function curlTelemetrySection(telemetryUrl: string): string {
@@ -73,18 +73,18 @@ curl -s -X POST '${telemetryUrl}' \\
   > /dev/null 2>&1 &
 \`\`\`
 
-Fire one after each of Steps 1–8, with \`step\` and \`metadata\` per this table. \`outcome\` is \`success\`, \`partial\`, \`fail\`, or \`skipped\`, describing how that step went. In \`metadata\`, omit any field you don't know, and always include \`"durationMs"\` (wall-clock milliseconds you spent on the step) when you can estimate it.
+Fire one after each of Steps 1–8, with \`step\` and \`metadata\` per this table. \`outcome\` is \`success\`, \`partial\`, \`fail\`, or \`skipped\`, describing how that step went. In \`metadata\`, omit any field you don't know, and always include \`"duration_ms"\` (wall-clock milliseconds you spent on the step) when you can estimate it.
 
 | After  | \`step\` | \`metadata\` fields |
 |--------|----------|--------------------|
-| Step 1 | \`precheck\` | \`"alreadyInstalled"\` (bool) |
-| Step 2 | \`explore\` | \`"framework"\` (e.g. "next"), \`"cspPresent"\` (bool) |
+| Step 1 | \`precheck\` | \`"already_installed"\` (bool) |
+| Step 2 | \`explore\` | \`"framework"\` (e.g. "next"), \`"csp_present"\` (bool) |
 | Step 3 | \`plan\` | \`"approved"\` (bool) |
-| Step 4 | \`install\` | \`"framework"\` (e.g. "next"), \`"cspModified"\` (bool) |
-| Step 5 | \`identify\` | \`"identityAdded"\` (bool) |
-| Step 6 | \`link_analytics\` | \`"analyticsProviders"\` (array of SDK names found) |
-| Step 7 | \`mask_pii\` | \`"maskedCount"\` (number), \`"privacyCheck"\` (bool) |
-| Step 8 | \`complete\` | \`"totalDurationMs"\`, \`"totalTokens"\` (whole-flow totals) |
+| Step 4 | \`install\` | \`"framework"\` (e.g. "next"), \`"csp_modified"\` (bool) |
+| Step 5 | \`identify\` | \`"identity_added"\` (bool) |
+| Step 6 | \`link_analytics\` | \`"analytics_providers"\` (array of SDK names found) |
+| Step 7 | \`mask_pii\` | \`"masked_count"\` (number), \`"privacy_check"\` (bool) |
+| Step 8 | \`complete\` | \`"total_duration_ms"\`, \`"total_tokens"\` (whole-flow totals) |
 
 Telemetry must never block or delay the install — if \`curl\` is unavailable, the variable is empty, or the request fails, skip silently and move on.`;
 }

--- a/src/prompt/build.ts
+++ b/src/prompt/build.ts
@@ -1,19 +1,28 @@
 import fs from 'node:fs';
-import { TELEMETRY_ENDPOINT } from '../config.js';
 import type { IntegrationSelection } from '../integrations.js';
 import { packageRootPath } from '../paths.js';
 
 export type PromptMode = 'headless' | 'interactive';
+
+/**
+ * How the prompt instructs the agent to report telemetry:
+ * - 'curl'  — headless terminal runs; the wizard hands the agent an auth
+ *   token via env and it POSTs WorkflowEvents directly.
+ * - 'mcp'   — GUI handoffs, where the wizard just guided the Subtext plugin
+ *   setup; the agent logs through the `telemetry-event` MCP tool.
+ * - 'none'  — telemetry declined/disabled, or an unknown agent (manual
+ *   handoff) with no safe way to authenticate.
+ */
+export type PromptTelemetry = 'curl' | 'mcp' | 'none';
 
 export interface BuildPromptInput {
   /** Org-specific capture snippet HTML fetched from the API. */
   snippet: string;
   selection: IntegrationSelection;
   mode: PromptMode;
-  /** Correlates agent-side telemetry with this wizard run. */
-  runId: string;
-  /** Telemetry checkpoints from inside the agent run. Off when telemetry is disabled. */
-  telemetryEnabled: boolean;
+  telemetry: PromptTelemetry;
+  /** Realm-aware /subtext/telemetry endpoint the curl checkpoints POST to. */
+  telemetryUrl: string;
 }
 
 const HEADLESS_MODE_SECTION = `## Mode: autonomous (headless)
@@ -24,19 +33,60 @@ const INTERACTIVE_MODE_SECTION = `## Mode: interactive
 
 Work through the steps with the user in this conversation, honoring every approval gate below.`;
 
-function telemetrySection(runId: string): string {
+/**
+ * GUI-handoff variant: the agent logs milestones through the Subtext
+ * plugin's `telemetry-event` MCP tool. Adapted from the settings-ui setup
+ * prompt (mn#107606), minus the consent ask — the wizard already asked in
+ * the CLI, and this section only renders when the user said yes.
+ */
+function mcpTelemetrySection(): string {
+  return `## Telemetry
+
+The user already agreed, during Subtext setup, that this install may log anonymous progress telemetry — step outcomes and timings, never code or data. Do not ask again. Log it with the \`telemetry-event\` MCP tool from the Subtext plugin (documented in the \`subtext-telemetry\` skill).
+
+Log one event before Step 1 — \`workflow="onboard" step="start"\` with \`harness\` (your coding tool) and \`model\` metadata — then one event as each of Steps 1–8 completes, with an \`outcome\` (\`success\`, \`partial\`, \`fail\`, or \`skipped\`) and that step's metadata fields:
+
+| After | Log step | Extra metadata |
+|-------|----------|----------------|
+| Step 1 | \`precheck\` | \`already_installed\` (bool) |
+| Step 2 | \`explore\` | \`framework\` (string), \`csp_present\` (bool) |
+| Step 3 | \`plan\` | \`approved\` (bool) |
+| Step 4 | \`install\` | \`framework\` (string), \`csp_modified\` (bool) |
+| Step 5 | \`identify\` | \`identity_added\` (bool) |
+| Step 6 | \`link_analytics\` | \`analytics_providers\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
+| Step 7 | \`mask_pii\` | \`masked_count\` (int), \`privacy_check\` (bool) |
+| Step 8 | \`complete\` | \`total_duration_ms\` (int), \`total_tokens\` (int) |
+
+Every event's metadata may also include \`duration_ms\` (int) and \`tokens\` (int) for that step when you can estimate them. Log each event at the moment the step finishes — not retroactively at the end — so durations and failure points are real. Metadata is a JSON object containing only these derived fields: never include file contents, code, secrets, or user data. Telemetry is fire-and-forget: if the tool is unavailable (e.g. the plugin isn't installed) or a call returns \`{"logged": false}\`, skip it silently and keep working — never block, retry, or abort the install because of telemetry. Do not announce telemetry calls to the user or mention them in your summaries.`;
+}
+
+function curlTelemetrySection(telemetryUrl: string): string {
   return `## Telemetry checkpoints
 
-As you finish each step below, fire a non-blocking background telemetry ping so setup progress is visible to the Subtext team:
+As you finish each step below, fire a non-blocking background telemetry ping so setup progress is visible to the Subtext team. The \`SUBTEXT_TELEMETRY_TOKEN\` environment variable is already set in your environment:
 
 \`\`\`sh
-curl -s -X POST '${TELEMETRY_ENDPOINT}' \\
+curl -s -X POST '${telemetryUrl}' \\
+  -H "Authorization: Bearer $SUBTEXT_TELEMETRY_TOKEN" \\
   -H 'Content-Type: application/json' \\
-  -d '{"event":"agent_step_completed","run_id":"${runId}","step":"<step number, 1-8>"}' \\
+  -d '{"workflow":"onboard","step":"<step>","outcome":"<outcome>","metadata":<metadata>}' \\
   > /dev/null 2>&1 &
 \`\`\`
 
-Fire one after each of Steps 1–8. Telemetry must never block or delay the install — if \`curl\` is unavailable or the request fails, skip silently and move on.`;
+Fire one after each of Steps 1–8, with \`step\` and \`metadata\` per this table. \`outcome\` is \`success\`, \`partial\`, \`fail\`, or \`skipped\`, describing how that step went. In \`metadata\`, omit any field you don't know, and always include \`"durationMs"\` (wall-clock milliseconds you spent on the step) when you can estimate it.
+
+| After  | \`step\` | \`metadata\` fields |
+|--------|----------|--------------------|
+| Step 1 | \`precheck\` | \`"alreadyInstalled"\` (bool) |
+| Step 2 | \`explore\` | \`"framework"\` (e.g. "next"), \`"cspPresent"\` (bool) |
+| Step 3 | \`plan\` | \`"approved"\` (bool) |
+| Step 4 | \`install\` | \`"cspModified"\` (bool) |
+| Step 5 | \`identify\` | \`"identityAdded"\` (bool) |
+| Step 6 | \`link_analytics\` | \`"analyticsProviders"\` (array of SDK names found) |
+| Step 7 | \`mask_pii\` | \`"maskedCount"\` (number), \`"privacyCheck"\` (bool) |
+| Step 8 | \`complete\` | \`"totalDurationMs"\`, \`"totalTokens"\` (whole-flow totals) |
+
+Telemetry must never block or delay the install — if \`curl\` is unavailable, the variable is empty, or the request fails, skip silently and move on.`;
 }
 
 function integrationsSection(selection: IntegrationSelection): string {
@@ -96,7 +146,12 @@ export function buildInstallPrompt(input: BuildPromptInput): string {
 
   const replacements: Record<string, string> = {
     MODE_SECTION: headless ? HEADLESS_MODE_SECTION : INTERACTIVE_MODE_SECTION,
-    TELEMETRY_SECTION: input.telemetryEnabled ? telemetrySection(input.runId) : '',
+    TELEMETRY_SECTION:
+      input.telemetry === 'curl'
+        ? curlTelemetrySection(input.telemetryUrl)
+        : input.telemetry === 'mcp'
+          ? mcpTelemetrySection()
+          : '',
     INTEGRATIONS_SECTION: integrationsSection(input.selection),
     SNIPPET: input.snippet,
     INTEGRATION_LINKAGE_EXAMPLES: linkageExamples(input.selection),

--- a/src/prompt/build.ts
+++ b/src/prompt/build.ts
@@ -48,16 +48,16 @@ Log one event before Step 1 — \`workflow="onboard" step="start"\` with \`harne
 
 | After | Log step | Extra metadata |
 |-------|----------|----------------|
-| Step 1 | \`precheck\` | \`already_installed\` (bool) |
-| Step 2 | \`explore\` | \`framework\` (string), \`csp_present\` (bool) |
+| Step 1 | \`precheck\` | \`alreadyInstalled\` (bool) |
+| Step 2 | \`explore\` | \`framework\` (string), \`cspPresent\` (bool) |
 | Step 3 | \`plan\` | \`approved\` (bool) |
-| Step 4 | \`install\` | \`framework\` (string), \`csp_modified\` (bool) |
-| Step 5 | \`identify\` | \`identity_added\` (bool) |
-| Step 6 | \`link_analytics\` | \`analytics_providers\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
-| Step 7 | \`mask_pii\` | \`masked_count\` (int), \`privacy_check\` (bool) |
-| Step 8 | \`complete\` | \`total_duration_ms\` (int), \`total_tokens\` (int) |
+| Step 4 | \`install\` | \`framework\` (string), \`cspModified\` (bool) |
+| Step 5 | \`identify\` | \`identityAdded\` (bool) |
+| Step 6 | \`link_analytics\` | \`analyticsProviders\` (string[] — names of every analytics/session-replay/error-monitoring/feature-flag SDK found) |
+| Step 7 | \`mask_pii\` | \`maskedCount\` (int), \`privacyCheck\` (bool) |
+| Step 8 | \`complete\` | \`totalDurationMs\` (int), \`totalTokens\` (int) |
 
-Every event's metadata may also include \`duration_ms\` (int) and \`tokens\` (int) for that step when you can estimate them. Log each event at the moment the step finishes — not retroactively at the end — so durations and failure points are real. Metadata is a JSON object containing only these derived fields: never include file contents, code, secrets, or user data. Telemetry is fire-and-forget: if the tool is unavailable (e.g. the plugin isn't installed) or a call returns \`{"logged": false}\`, skip it silently and keep working — never block, retry, or abort the install because of telemetry. Do not announce telemetry calls to the user or mention them in your summaries.`;
+Every event's metadata may also include \`durationMs\` (int) and \`tokens\` (int) for that step when you can estimate them. Log each event at the moment the step finishes — not retroactively at the end — so durations and failure points are real. Metadata is a JSON object containing only these derived fields: never include file contents, code, secrets, or user data. Telemetry is fire-and-forget: if the tool is unavailable (e.g. the plugin isn't installed) or a call returns \`{"logged": false}\`, skip it silently and keep working — never block, retry, or abort the install because of telemetry. Do not announce telemetry calls to the user or mention them in your summaries.`;
 }
 
 function curlTelemetrySection(telemetryUrl: string): string {

--- a/src/prompt/build.ts
+++ b/src/prompt/build.ts
@@ -80,7 +80,7 @@ Fire one after each of Steps 1–8, with \`step\` and \`metadata\` per this tabl
 | Step 1 | \`precheck\` | \`"alreadyInstalled"\` (bool) |
 | Step 2 | \`explore\` | \`"framework"\` (e.g. "next"), \`"cspPresent"\` (bool) |
 | Step 3 | \`plan\` | \`"approved"\` (bool) |
-| Step 4 | \`install\` | \`"cspModified"\` (bool) |
+| Step 4 | \`install\` | \`"framework"\` (e.g. "next"), \`"cspModified"\` (bool) |
 | Step 5 | \`identify\` | \`"identityAdded"\` (bool) |
 | Step 6 | \`link_analytics\` | \`"analyticsProviders"\` (array of SDK names found) |
 | Step 7 | \`mask_pii\` | \`"maskedCount"\` (number), \`"privacyCheck"\` (bool) |

--- a/src/run.ts
+++ b/src/run.ts
@@ -98,7 +98,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     });
 
     if (options.printPrompt) {
-      sendStart('print-prompt');
+      // No handoff happens here — we only print the prompt — so this must not
+      // fire a `start` event, which would inflate the funnel with runs that
+      // never began.
       console.log(prompt);
       await telemetry.flush();
       return 0;

--- a/src/run.ts
+++ b/src/run.ts
@@ -58,7 +58,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     //    steers the prompt — analytics_providers telemetry is left to what
     //    the agent actually detects at the link_analytics step.
     const selection = await selectIntegrations(options);
-    const sendStart = (harness: string) => telemetry.step('start', 'success', { harness });
+    // No outcome: an in-progress handoff. `finish` supplies fail/skipped if
+    // the run ends early, and `complete` closes a successful funnel entry.
+    const sendStart = (harness: string) => telemetry.step('start', undefined, { harness });
 
     // 4. Find the user's coding agents and pick one. We never bring our own
     //    agent — the install always runs on a harness the user already has.

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,12 +8,15 @@ import { WIZARD_VERSION, telemetryUrl } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
 import { guidePluginSetup } from './plugin.js';
-import { buildInstallPrompt } from './prompt/build.js';
+import { buildInstallPrompt, type PromptTelemetry } from './prompt/build.js';
 import { fetchCaptureSnippet } from './snippet.js';
 import { Telemetry } from './telemetry.js';
 
 export async function runWizard(options: WizardOptions): Promise<number> {
   const telemetry = new Telemetry(options.telemetry, options.debug);
+  // Set once an agent is chosen so a post-selection cancel/fail (thrown out of
+  // scope of `chosen`) can still attach the harness the rest of the funnel uses.
+  let selectedHarness: string | undefined;
 
   await showLogo();
   p.intro(`${pc.bgCyan(pc.black(' Subtext '))} setup ${pc.dim(`v${WIZARD_VERSION}`)}`);
@@ -77,25 +80,40 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     const chosen = await chooseAgent(detected, options);
     const isTerminalRun = chosen !== MANUAL_CHOICE && chosen.definition.kind === 'terminal';
     const isAppRun = chosen !== MANUAL_CHOICE && chosen.definition.kind === 'app';
+    selectedHarness = chosen === MANUAL_CHOICE ? 'manual' : chosen.definition.id;
 
-    // 5. Assemble the install prompt. Terminal agents get the autonomous
-    //    variant (no approval gates); app handoffs keep the interactive one.
-    //    Agent-side telemetry: terminal runs curl the endpoint with a token
-    //    we pass via env; GUI runs log through the Subtext plugin's MCP tool
-    //    (set up below); manual handoffs get none — we won't paste the
-    //    user's access token into a clipboard prompt (flagged for review).
+    // 5. GUI apps: set up the Subtext plugin before building the prompt. Whether
+    //    the plugin is actually present decides who owns telemetry, so it must be
+    //    known before the prompt's telemetry section is chosen. Skipped for
+    //    --print-prompt, which only previews the prompt and never hands off.
+    let pluginReady = false;
+    if (isAppRun && !options.printPrompt) {
+      pluginReady = await guidePluginSetup(chosen, auth.region);
+      telemetry.note('plugin_setup', { agent: chosen.definition.id, ready: pluginReady });
+    }
+
+    // 6. Assemble the install prompt. Terminal agents get the autonomous variant
+    //    (no approval gates); app handoffs keep the interactive one.
+    //    Agent-side telemetry: terminal runs curl the endpoint with a token we
+    //    pass via env; GUI runs log through the plugin's MCP tool, but ONLY when
+    //    that plugin is set up — otherwise the wizard owns the `start` (below)
+    //    and the prompt must not also tell the agent to log one, or a
+    //    still-present plugin would double-count the funnel. Manual handoffs get
+    //    none — we won't paste the user's access token into a clipboard prompt
+    //    (flagged for review). --print-prompt previews the GUI happy path (mcp).
+    const promptTelemetry: PromptTelemetry =
+      !telemetryEnabled || options.mock
+        ? 'none'
+        : isTerminalRun
+          ? 'curl'
+          : isAppRun && (pluginReady || options.printPrompt)
+            ? 'mcp'
+            : 'none';
     const prompt = buildInstallPrompt({
       snippet,
       selection,
       mode: isTerminalRun ? 'headless' : 'interactive',
-      telemetry:
-        !telemetryEnabled || options.mock
-          ? 'none'
-          : isTerminalRun
-            ? 'curl'
-            : isAppRun
-              ? 'mcp'
-              : 'none',
+      telemetry: promptTelemetry,
       telemetryUrl: telemetryUrl(auth.region),
     });
 
@@ -108,7 +126,7 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       return 0;
     }
 
-    // 6. Hand off to the agent.
+    // 7. Hand off to the agent.
     if (chosen === MANUAL_CHOICE) {
       sendStart('manual');
       let copied = true;
@@ -133,18 +151,12 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       return 0;
     }
 
-    // GUI apps only: set up the Subtext plugin before handing off, so the
-    // agent has the subtext MCP tools the prompt relies on (telemetry,
-    // session review).
-    if (isAppRun) {
-      const ready = await guidePluginSetup(chosen, auth.region);
-      telemetry.note('plugin_setup', { agent: chosen.definition.id, ready });
-      // With the plugin installed the agent logs its own richer start event
-      // (harness + model) through the MCP tool. Without it, those MCP calls
-      // silently no-op — so the wizard records the start itself, otherwise a
-      // consented GUI handoff would produce no funnel events at all.
-      if (!ready) sendStart(chosen.definition.id);
-    }
+    // GUI without the plugin: the prompt carries no telemetry section, so the
+    // agent won't log anything — the wizard records the start itself, otherwise
+    // a consented GUI handoff would produce no funnel events at all. With the
+    // plugin the agent logs its own richer start (harness + model) via MCP, so
+    // the wizard stays quiet to avoid double-counting.
+    if (isAppRun && !pluginReady) sendStart(chosen.definition.id);
 
     if (isTerminalRun) {
       const confirmed = options.agent
@@ -153,8 +165,6 @@ export async function runWizard(options: WizardOptions): Promise<number> {
             message: `Run the install now with ${chosen.definition.name}? It will edit files in ${options.dir} (auto-accepting edits).`,
           });
       if (p.isCancel(confirmed) || !confirmed) throw new CancelledError();
-      // GUI runs handle their own start above: with the plugin, the agent logs
-      // it (with harness and model) through the MCP tool per the prompt.
       sendStart(chosen.definition.id);
     }
 
@@ -203,15 +213,18 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     await telemetry.flush();
     return result.mode === 'ran' ? (result.exitCode ?? 1) : 0;
   } catch (error) {
+    // Attach the harness if an agent was already chosen, so post-selection
+    // cancel/fail events carry the same agent id as the rest of the funnel.
+    const harnessMeta = selectedHarness ? { harness: selectedHarness } : {};
     if (error instanceof CancelledError) {
-      telemetry.finish('skipped');
+      telemetry.finish('skipped', harnessMeta);
       p.cancel('Setup cancelled — nothing was changed.');
       await telemetry.flush();
       return 130;
     }
     // The endpoint has no field for the error message itself (flagged for
     // review) — only the fail outcome goes up.
-    telemetry.finish('fail');
+    telemetry.finish('fail', harnessMeta);
     telemetry.note('wizard_error', {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,9 +4,10 @@ import pc from 'picocolors';
 import { authenticate } from './auth.js';
 import { chooseAgent, detectAgents, MANUAL_CHOICE } from './agents/index.js';
 import type { WizardOptions } from './config.js';
-import { WIZARD_VERSION } from './config.js';
+import { WIZARD_VERSION, telemetryUrl } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
+import { guidePluginSetup } from './plugin.js';
 import { buildInstallPrompt } from './prompt/build.js';
 import { fetchCaptureSnippet } from './snippet.js';
 import { Telemetry } from './telemetry.js';
@@ -23,24 +24,41 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     p.log.warn('Mock mode: no real network calls will be made.');
   }
 
-  telemetry.capture('wizard_started', { mock: options.mock, dir_provided: options.dir !== process.cwd() });
+  telemetry.note('wizard_started', { mock: options.mock, dir_provided: options.dir !== process.cwd() });
 
   try {
     // 1. Login (browser flow) so we can fetch the org-specific snippet.
     const auth = await authenticate(options);
-    telemetry.setTag('org_id', auth.orgId);
-    telemetry.capture('auth_completed', { via: options.apiKey ? 'api_key' : 'browser' });
+
+    // Consent gate: nothing is collected unless the user says yes here.
+    // --no-telemetry skips the question (already opted out).
+    let telemetryEnabled = options.telemetry;
+    if (telemetryEnabled) {
+      const consent = await p.confirm({
+        message:
+          'Is it OK if Subtext collects anonymous telemetry about this install session (step progress, outcomes, and timings — never your code or data)? It helps improve the onboarding flow.',
+      });
+      if (p.isCancel(consent)) throw new CancelledError();
+      telemetryEnabled = consent;
+      if (!consent) telemetry.disable();
+    }
+    // The telemetry endpoint needs an authenticated session, so delivery can
+    // only start now — anything that fails before login goes unreported
+    // (flagged for review). Mock runs never send real events.
+    if (telemetryEnabled && !options.mock) {
+      telemetry.authorize(telemetryUrl(auth.region), auth.accessToken);
+    }
+    telemetry.note('auth_completed', { via: options.apiKey ? 'api_key' : 'browser' });
 
     // 2. Org-specific capture snippet.
     const snippet = await fetchCaptureSnippet(auth, options);
-    telemetry.capture('snippet_fetched');
+    telemetry.note('snippet_fetched');
 
-    // 3. Which integrations should the agent look for?
+    // 3. Which integrations should the agent look for? The selection only
+    //    steers the prompt — analytics_providers telemetry is left to what
+    //    the agent actually detects at the link_analytics step.
     const selection = await selectIntegrations(options);
-    telemetry.capture('integrations_selected', {
-      integrations: selection.integrations.map((i) => i.id),
-      other: selection.other,
-    });
+    const sendStart = (harness: string) => telemetry.step('start', 'success', { harness });
 
     // 4. Find the user's coding agents and pick one. We never bring our own
     //    agent — the install always runs on a harness the user already has.
@@ -52,23 +70,35 @@ export async function runWizard(options: WizardOptions): Promise<number> {
         ? `Detected: ${detected.map((d) => d.definition.name).join(', ')}`
         : 'No coding agents detected.',
     );
-    telemetry.capture('agents_detected', { agents: detected.map((d) => d.definition.id) });
+    telemetry.note('agents_detected', { agents: detected.map((d) => d.definition.id) });
 
     const chosen = await chooseAgent(detected, options);
     const isTerminalRun = chosen !== MANUAL_CHOICE && chosen.definition.kind === 'terminal';
+    const isAppRun = chosen !== MANUAL_CHOICE && chosen.definition.kind === 'app';
 
     // 5. Assemble the install prompt. Terminal agents get the autonomous
     //    variant (no approval gates); app handoffs keep the interactive one.
+    //    Agent-side telemetry: terminal runs curl the endpoint with a token
+    //    we pass via env; GUI runs log through the Subtext plugin's MCP tool
+    //    (set up below); manual handoffs get none — we won't paste the
+    //    user's access token into a clipboard prompt (flagged for review).
     const prompt = buildInstallPrompt({
       snippet,
       selection,
       mode: isTerminalRun ? 'headless' : 'interactive',
-      runId: telemetry.runId,
-      telemetryEnabled: options.telemetry,
+      telemetry:
+        !telemetryEnabled || options.mock
+          ? 'none'
+          : isTerminalRun
+            ? 'curl'
+            : isAppRun
+              ? 'mcp'
+              : 'none',
+      telemetryUrl: telemetryUrl(auth.region),
     });
 
     if (options.printPrompt) {
-      telemetry.capture('prompt_printed');
+      sendStart('print-prompt');
       console.log(prompt);
       await telemetry.flush();
       return 0;
@@ -76,13 +106,14 @@ export async function runWizard(options: WizardOptions): Promise<number> {
 
     // 6. Hand off to the agent.
     if (chosen === MANUAL_CHOICE) {
+      sendStart('manual');
       let copied = true;
       try {
         await clipboard.write(prompt);
       } catch {
         copied = false;
       }
-      telemetry.capture('manual_handoff', { clipboard: copied });
+      telemetry.note('manual_handoff', { clipboard: copied });
       if (copied) {
         p.log.success('The install prompt is on your clipboard.');
         p.note(
@@ -98,10 +129,13 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       return 0;
     }
 
-    telemetry.capture('agent_launch_started', {
-      agent: chosen.definition.id,
-      kind: chosen.definition.kind,
-    });
+    // GUI apps only: set up the Subtext plugin before handing off, so the
+    // agent has the subtext MCP tools the prompt relies on (telemetry,
+    // session review).
+    if (isAppRun) {
+      const ready = await guidePluginSetup(chosen, auth.region);
+      telemetry.note('plugin_setup', { agent: chosen.definition.id, ready });
+    }
 
     if (isTerminalRun) {
       const confirmed = options.agent
@@ -110,6 +144,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
             message: `Run the install now with ${chosen.definition.name}? It will edit files in ${options.dir} (auto-accepting edits).`,
           });
       if (p.isCancel(confirmed) || !confirmed) throw new CancelledError();
+      // GUI runs skip this: their agent logs its own start event (with
+      // harness and model) through the MCP tool, per the prompt.
+      sendStart(chosen.definition.id);
     }
 
     const result = await chosen.definition.launch({
@@ -117,14 +154,27 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       cwd: options.dir,
       binaryPath: chosen.binaryPath,
       debug: options.debug,
-      onEvent: (event, properties) => telemetry.capture(event, properties),
+      // Terminal agents fire the per-step telemetry checkpoints themselves;
+      // this token authenticates those curls. It is the user's own OAuth
+      // access token, exposed only to a child process on their machine.
+      env:
+        isTerminalRun && telemetryEnabled && !options.mock
+          ? { SUBTEXT_TELEMETRY_TOKEN: auth.accessToken }
+          : undefined,
+      onEvent: (event, properties) => telemetry.note(event, properties),
     });
 
-    telemetry.capture('wizard_completed', {
+    telemetry.note('wizard_completed', {
       agent: chosen.definition.id,
       mode: result.mode,
       exit_code: result.exitCode ?? null,
     });
+    // On success the agent's own step-8 checkpoint is the complete event;
+    // sending another here would double-count the funnel. A failed run can't
+    // be trusted to have reported itself, so the wizard records it.
+    if (result.mode === 'ran' && result.exitCode !== 0) {
+      telemetry.step('complete', 'fail', { harness: chosen.definition.id });
+    }
 
     if (result.mode === 'handoff') {
       p.note(result.followUp?.join('\n') ?? '', 'Next steps');
@@ -145,12 +195,17 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     return result.mode === 'ran' ? (result.exitCode ?? 1) : 0;
   } catch (error) {
     if (error instanceof CancelledError) {
-      telemetry.capture('wizard_cancelled');
+      telemetry.finish('skipped');
       p.cancel('Setup cancelled — nothing was changed.');
       await telemetry.flush();
       return 130;
     }
-    telemetry.captureError(error);
+    // The endpoint has no field for the error message itself (flagged for
+    // review) — only the fail outcome goes up.
+    telemetry.finish('fail');
+    telemetry.note('wizard_error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     p.log.error(error instanceof Error ? error.message : String(error));
     p.outro(pc.red('Setup failed.'));
     await telemetry.flush();

--- a/src/run.ts
+++ b/src/run.ts
@@ -94,27 +94,31 @@ export async function runWizard(options: WizardOptions): Promise<number> {
 
     // 6. Assemble the install prompt. Terminal agents get the autonomous variant
     //    (no approval gates); app handoffs keep the interactive one.
-    //    Agent-side telemetry: terminal runs curl the endpoint with a token we
-    //    pass via env; GUI runs log through the plugin's MCP tool, but ONLY when
-    //    that plugin is set up — otherwise the wizard owns the `start` (below)
-    //    and the prompt must not also tell the agent to log one, or a
-    //    still-present plugin would double-count the funnel. Manual handoffs get
-    //    none — we won't paste the user's access token into a clipboard prompt
-    //    (flagged for review). --print-prompt previews the GUI happy path (mcp).
+    //    Telemetry never hands a credential to the agent's process — that would
+    //    leak the OAuth token to any install subprocess (npm postinstall etc.):
+    //    - terminal runs ('stdout') have the agent PRINT per-step markers the
+    //      wizard parses out of the output and sends with its own token;
+    //    - GUI handoffs ('mcp') log through the Subtext plugin's MCP tool, but
+    //      only when that plugin is set up — otherwise the wizard owns the
+    //      `start` (below) and the prompt must not tell the agent to log one
+    //      too, or a still-present plugin would double-count.
+    //    Either way the wizard owns the terminal `start`/`complete` bookends.
+    //    --print-prompt always previews the manual-handoff variant (interactive,
+    //    no agent-side telemetry): a printed prompt is pasted by hand, so no
+    //    wizard is attached to parse markers and no approval gate may be skipped.
     const promptTelemetry: PromptTelemetry =
-      !telemetryEnabled || options.mock
+      !telemetryEnabled || options.mock || options.printPrompt
         ? 'none'
         : isTerminalRun
-          ? 'curl'
-          : isAppRun && (pluginReady || options.printPrompt)
+          ? 'stdout'
+          : isAppRun && pluginReady
             ? 'mcp'
             : 'none';
     const prompt = buildInstallPrompt({
       snippet,
       selection,
-      mode: isTerminalRun ? 'headless' : 'interactive',
+      mode: isTerminalRun && !options.printPrompt ? 'headless' : 'interactive',
       telemetry: promptTelemetry,
-      telemetryUrl: telemetryUrl(auth.region),
     });
 
     if (options.printPrompt) {
@@ -168,19 +172,28 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       sendStart(chosen.definition.id);
     }
 
+    // Marker lines come from an untrusted stream (the agent echoes output of
+    // arbitrary repo code), so cap what it can make the wizard send: one event
+    // per step, first marker wins. Legitimate cardinality is one per step.
+    const sentMarkerSteps = new Set<string>();
+    let agentInstallSucceeded = false;
+
     const result = await chosen.definition.launch({
       prompt,
       cwd: options.dir,
       binaryPath: chosen.binaryPath,
       debug: options.debug,
-      // Terminal agents fire the per-step telemetry checkpoints themselves;
-      // this token authenticates those curls. It is the user's own OAuth
-      // access token, exposed only to a child process on their machine.
-      env:
-        isTerminalRun && telemetryEnabled && !options.mock
-          ? { SUBTEXT_TELEMETRY_TOKEN: auth.accessToken }
-          : undefined,
       onEvent: (event, properties) => telemetry.note(event, properties),
+      // Per-step markers the agent printed to stdout. The wizard sends them
+      // with its own token, so no credential ever reaches the agent; the
+      // parser allowlists steps and metadata fields, and `harness` is written
+      // last so a marker can never override attribution.
+      onTelemetry: ({ step, outcome, metadata }) => {
+        if (sentMarkerSteps.has(step)) return;
+        sentMarkerSteps.add(step);
+        if (step === 'install' && outcome === 'success') agentInstallSucceeded = true;
+        telemetry.step(step, outcome, { ...metadata, harness: chosen.definition.id });
+      },
     });
 
     telemetry.note('wizard_completed', {
@@ -188,11 +201,21 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       mode: result.mode,
       exit_code: result.exitCode ?? null,
     });
-    // On success the agent's own step-8 checkpoint is the complete event;
-    // sending another here would double-count the funnel. A failed run can't
-    // be trusted to have reported itself, so the wizard records it.
-    if (result.mode === 'ran' && result.exitCode !== 0) {
-      telemetry.step('complete', 'fail', { harness: chosen.definition.id });
+    // Terminal runs (`ran`) never hand the agent a credential, so the wizard
+    // owns their `complete` event. Exit code 0 only proves the CLI ran to
+    // completion — codex/gemini exit 0 even when the model refused or abandoned
+    // the install — so `success` additionally requires the agent's own
+    // install-step marker; exit 0 without it is recorded as `partial`. (When
+    // the prompt carried no marker instructions, exit code is all we have.)
+    // GUI handoffs log their own `complete` via the plugin's MCP tool.
+    if (result.mode === 'ran') {
+      const outcome =
+        result.exitCode !== 0
+          ? 'fail'
+          : agentInstallSucceeded || promptTelemetry !== 'stdout'
+            ? 'success'
+            : 'partial';
+      telemetry.step('complete', outcome, { harness: chosen.definition.id });
     }
 
     if (result.mode === 'handoff') {

--- a/src/run.ts
+++ b/src/run.ts
@@ -139,6 +139,11 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     if (isAppRun) {
       const ready = await guidePluginSetup(chosen, auth.region);
       telemetry.note('plugin_setup', { agent: chosen.definition.id, ready });
+      // With the plugin installed the agent logs its own richer start event
+      // (harness + model) through the MCP tool. Without it, those MCP calls
+      // silently no-op — so the wizard records the start itself, otherwise a
+      // consented GUI handoff would produce no funnel events at all.
+      if (!ready) sendStart(chosen.definition.id);
     }
 
     if (isTerminalRun) {
@@ -148,8 +153,8 @@ export async function runWizard(options: WizardOptions): Promise<number> {
             message: `Run the install now with ${chosen.definition.name}? It will edit files in ${options.dir} (auto-accepting edits).`,
           });
       if (p.isCancel(confirmed) || !confirmed) throw new CancelledError();
-      // GUI runs skip this: their agent logs its own start event (with
-      // harness and model) through the MCP tool, per the prompt.
+      // GUI runs handle their own start above: with the plugin, the agent logs
+      // it (with harness and model) through the MCP tool per the prompt.
       sendStart(chosen.definition.id);
     }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -34,9 +34,9 @@ export type WorkflowStep =
 export type WorkflowOutcome = 'success' | 'partial' | 'fail' | 'skipped';
 
 /** protojson form of lidar's WorkflowEventMetadata. Field names mirror the
- * proto exactly (snake_case) so wizard-sent events, the curl checkpoints, and
- * the MCP telemetry-event tool all speak one convention. Fields are sparse —
- * only those relevant to a given step are set. */
+ * proto exactly (snake_case) so wizard-sent events and the MCP telemetry-event
+ * tool all speak one convention. Fields are sparse — only those relevant to a
+ * given step are set. */
 export interface WorkflowEventMetadata {
   duration_ms?: number;
   tokens?: number;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -33,24 +33,26 @@ export type WorkflowStep =
 /** The lidar Outcome enum; empty string means "in progress". */
 export type WorkflowOutcome = 'success' | 'partial' | 'fail' | 'skipped';
 
-/** protojson form of lidar's WorkflowEventMetadata. Fields are sparse — only
- * those relevant to a given step are set. */
+/** protojson form of lidar's WorkflowEventMetadata. Field names mirror the
+ * proto exactly (snake_case) so wizard-sent events, the curl checkpoints, and
+ * the MCP telemetry-event tool all speak one convention. Fields are sparse —
+ * only those relevant to a given step are set. */
 export interface WorkflowEventMetadata {
-  durationMs?: number;
+  duration_ms?: number;
   tokens?: number;
   harness?: string;
   model?: string;
-  alreadyInstalled?: boolean;
+  already_installed?: boolean;
   framework?: string;
-  cspPresent?: boolean;
+  csp_present?: boolean;
   approved?: boolean;
-  cspModified?: boolean;
-  identityAdded?: boolean;
-  analyticsProviders?: string[];
-  maskedCount?: number;
-  privacyCheck?: boolean;
-  totalDurationMs?: number;
-  totalTokens?: number;
+  csp_modified?: boolean;
+  identity_added?: boolean;
+  analytics_providers?: string[];
+  masked_count?: number;
+  privacy_check?: boolean;
+  total_duration_ms?: number;
+  total_tokens?: number;
 }
 
 export class Telemetry {
@@ -79,7 +81,7 @@ export class Telemetry {
   }
 
   /**
-   * Send one WorkflowEvent. `durationMs` (on start) and `totalDurationMs`
+   * Send one WorkflowEvent. `duration_ms` (on start) and `total_duration_ms`
    * (on complete) default to time since the wizard launched. The server
    * stamps org, email, and timestamp from the session.
    */
@@ -87,9 +89,9 @@ export class Telemetry {
     if (!this.enabled) return;
     if (step === 'start') {
       this.startSent = true;
-      metadata = { durationMs: Date.now() - this.startedAt, ...metadata };
+      metadata = { duration_ms: Date.now() - this.startedAt, ...metadata };
     } else if (step === 'complete') {
-      metadata = { totalDurationMs: Date.now() - this.startedAt, ...metadata };
+      metadata = { total_duration_ms: Date.now() - this.startedAt, ...metadata };
     }
     const payload = {
       workflow: 'onboard',

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,51 +1,113 @@
-import { randomUUID } from 'node:crypto';
-import os from 'node:os';
-import { TELEMETRY_ENDPOINT, WIZARD_VERSION } from './config.js';
+import { WIZARD_VERSION } from './config.js';
 
 /**
- * Fire-and-forget telemetry. Events are POSTed in the background as they
- * happen; nothing ever blocks the wizard and failures are swallowed. A final
- * flush() with a short deadline runs at exit.
+ * Fire-and-forget telemetry against the real `/subtext/telemetry` endpoint
+ * (lidar). The endpoint accepts a protojson `WorkflowEvent` (lidar.proto) and
+ * requires an authenticated session, so nothing can be delivered until the
+ * user has logged in — call authorize() with the OAuth access token first.
+ * Events are POSTed in the background as they happen; nothing ever blocks the
+ * wizard and failures are swallowed. A final flush() with a short deadline
+ * runs at exit.
  *
- * The endpoint is a PLACEHOLDER — see config.ts.
+ * Known backend gaps (flagged for review, see PR description):
+ * - No run-correlation id on WorkflowEvent, so wizard-side and agent-side
+ *   events from one run can only be joined by org/email/time.
+ * - No wizard-version or error-message metadata fields.
+ * - Events fired before login (e.g. auth failures) cannot be delivered at all.
  */
+
+/** Steps accepted by the endpoint — the lidar WorkflowStep enum. Anything
+ * else is rejected with 400, so granular CLI milestones that don't map to a
+ * step go through note() (debug-only) instead. */
+export type WorkflowStep =
+  | 'start'
+  | 'precheck'
+  | 'explore'
+  | 'plan'
+  | 'install'
+  | 'identify'
+  | 'link_analytics'
+  | 'mask_pii'
+  | 'complete';
+
+/** The lidar Outcome enum; empty string means "in progress". */
+export type WorkflowOutcome = 'success' | 'partial' | 'fail' | 'skipped';
+
+/** protojson form of lidar's WorkflowEventMetadata. Fields are sparse — only
+ * those relevant to a given step are set. */
+export interface WorkflowEventMetadata {
+  durationMs?: number;
+  tokens?: number;
+  harness?: string;
+  model?: string;
+  alreadyInstalled?: boolean;
+  framework?: string;
+  cspPresent?: boolean;
+  approved?: boolean;
+  cspModified?: boolean;
+  identityAdded?: boolean;
+  analyticsProviders?: string[];
+  maskedCount?: number;
+  privacyCheck?: boolean;
+  totalDurationMs?: number;
+  totalTokens?: number;
+}
+
 export class Telemetry {
-  readonly runId = randomUUID();
+  private endpoint?: string;
+  private accessToken?: string;
+  private startSent = false;
   private pending: Promise<unknown>[] = [];
-  private base: Record<string, unknown>;
+  private readonly startedAt = Date.now();
 
   constructor(
     private enabled: boolean,
     private debug: boolean,
-  ) {
-    this.base = {
-      wizard_version: WIZARD_VERSION,
-      platform: process.platform,
-      arch: process.arch,
-      node_version: process.version,
-      os_release: os.release(),
-    };
+  ) {}
+
+  /** Enable delivery once the user is logged in. Events fired before this
+   * are dropped (visible under --debug) — the endpoint rejects
+   * unauthenticated requests, so there is nowhere to send them. */
+  authorize(endpoint: string, accessToken: string): void {
+    this.endpoint = endpoint;
+    this.accessToken = accessToken;
   }
 
-  /** Attach a property to every subsequent event (e.g. org id after login). */
-  setTag(key: string, value: unknown): void {
-    this.base[key] = value;
+  /** Turn collection off for the rest of the run (user declined consent). */
+  disable(): void {
+    this.enabled = false;
   }
 
-  capture(event: string, properties: Record<string, unknown> = {}): void {
+  /**
+   * Send one WorkflowEvent. `durationMs` (on start) and `totalDurationMs`
+   * (on complete) default to time since the wizard launched. The server
+   * stamps org, email, and timestamp from the session.
+   */
+  step(step: WorkflowStep, outcome?: WorkflowOutcome, metadata: WorkflowEventMetadata = {}): void {
     if (!this.enabled) return;
+    if (step === 'start') {
+      this.startSent = true;
+      metadata = { durationMs: Date.now() - this.startedAt, ...metadata };
+    } else if (step === 'complete') {
+      metadata = { totalDurationMs: Date.now() - this.startedAt, ...metadata };
+    }
     const payload = {
-      event,
-      run_id: this.runId,
-      timestamp: new Date().toISOString(),
-      properties: { ...this.base, ...properties },
+      workflow: 'onboard',
+      step,
+      ...(outcome ? { outcome } : {}),
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     };
     if (this.debug) {
-      console.error(`[telemetry] ${event} ${JSON.stringify(properties)}`);
+      console.error(`[telemetry] ${JSON.stringify(payload)}`);
     }
-    const req = fetch(TELEMETRY_ENDPOINT, {
+    if (!this.endpoint || !this.accessToken) return;
+    const req = fetch(this.endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+        'User-Agent': `subtext-wizard/${WIZARD_VERSION}`,
+      },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(3_000),
     }).catch(() => {
@@ -54,9 +116,22 @@ export class Telemetry {
     this.pending.push(req);
   }
 
-  captureError(error: unknown, context: Record<string, unknown> = {}): void {
-    const message = error instanceof Error ? error.message : String(error);
-    this.capture('wizard_error', { ...context, error: message });
+  /**
+   * Report how the run ended. If the wizard died before reaching the agent
+   * handoff, the funnel entry itself carries the outcome (start/fail or
+   * start/skipped); after handoff it lands as a complete event instead.
+   */
+  finish(outcome: WorkflowOutcome, metadata: WorkflowEventMetadata = {}): void {
+    this.step(this.startSent ? 'complete' : 'start', outcome, metadata);
+  }
+
+  /** Debug-only breadcrumb for CLI milestones that have no corresponding
+   * WorkflowStep on the backend (auth_completed, agents_detected, tool use…).
+   * Flagged for review — these are dropped, not sent. */
+  note(event: string, properties: Record<string, unknown> = {}): void {
+    if (this.debug) {
+      console.error(`[telemetry:note] ${event} ${JSON.stringify(properties)}`);
+    }
   }
 
   /** Wait briefly for in-flight events, then give up. */


### PR DESCRIPTION
## What

Wires the wizard's telemetry (previously a placeholder endpoint) to the real `POST /subtext/telemetry` endpoint added in cowpaths/mn#107603, gated behind an explicit consent question, and adds a Subtext plugin setup step for GUI-agent handoffs.

### Real telemetry endpoint

- Events are protojson `WorkflowEvent` payloads (`workflow: "onboard"`, a step from the backend's enum, optional outcome, typed metadata), POSTed to the realm-aware `{api base}/subtext/telemetry` with `Authorization: Bearer <OAuth access token>`. Still fire-and-forget: nothing blocks the wizard, failures are swallowed, and a 2s-deadline flush runs at exit. `SUBTEXT_TELEMETRY_URL` overrides the endpoint for testing.
- The endpoint requires an authenticated session, so delivery starts after login; `--mock` never sends real events.

### Consent gate

Right after login the wizard asks: *"Is it OK if Subtext collects anonymous telemetry about this install session (step progress, outcomes, and timings — never your code or data)?"* Declining (or `--no-telemetry`, which skips the question) disables everything below — wizard events, prompt telemetry sections, and the agent token.

### Event model

- **Wizard-side**: a `start` event (`harness`, `durationMs`) when a terminal or manual run reaches handoff; `complete`/`fail` if a terminal agent exits nonzero; `start`- or `complete`-with-`fail`/`skipped` if the CLI errors or is cancelled, sent before exit.
- **Agent-side, terminal runs** (Claude Code / Codex / Gemini): the headless prompt instructs the agent to `curl` one event per install step (`precheck` → `complete`) with the per-step metadata fields from `lidar.proto`, authenticated via a `SUBTEXT_TELEMETRY_TOKEN` env var the wizard sets on the child process.
- **Agent-side, GUI handoffs** (Cursor / Windsurf / VS Code / Zed / Claude Desktop): the prompt gets a telemetry section adapted from cowpaths/mn#107606 — the agent logs `start` (with `harness`/`model`) and per-step events through the Subtext plugin's `telemetry-event` MCP tool. One deviation from that PR: the consent-ask block is replaced with "the user already agreed — do not ask again," since the CLI asks first and the section only renders on a yes.
- **Manual handoffs**: no agent-side checkpoints — that would mean pasting the user's access token into a clipboard prompt.
- `analytics_providers` is only ever what the agent detects at `link_analytics`; the integration picker's selection just steers the prompt, not telemetry.

### Plugin setup for GUI agents

When the user picks an app-kind agent, the wizard now walks them through installing the Subtext plugin (fullstorydev/subtext) before opening the app — Marketplace for Cursor, custom connector (realm-aware `{api base}/mcp/subtext`) for Claude Desktop, `npx openskills install` + MCP config for the rest. A confirm gates the handoff; "no" continues without the plugin (the prompt treats a missing tool as skip-silently).

Also syncs `WIZARD_VERSION` to 0.1.2 (the release bump missed it) and updates the README.

## Flagged for future backend review

- No run-correlation id on `WorkflowEvent` — wizard- and agent-side events join only by org/email/time.
- No error-message metadata field — only the `fail` outcome is reported (message stays in `--debug` output).
- Pre-login failures are unreportable (endpoint requires auth).
- No wizard-version field on the event (sent as `User-Agent` but ulated on wizard-sent `start` events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth-backed telemetry delivery and onboarding order for GUI agents; token stays in-process but untrusted stdout markers are sanitized before POST.
> 
> **Overview**
> Replaces the placeholder telemetry URL with authenticated **`WorkflowEvent`** posts to **`/subtext/telemetry`**, adds an explicit **consent prompt** after login (`--no-telemetry` still opts out), and bumps **`WIZARD_VERSION`** to 0.1.2.
> 
> **Wizard-side funnel:** `Telemetry` now **`authorize()`**s with the OAuth token and emits **`start` / step / `complete`** events (CLI milestones like `auth_completed` are debug-only **`note()`**s). Terminal runs get wizard-owned **`complete`** outcomes—exit code 0 alone is **`partial`** unless an **`install`/`success`** stdout marker was seen.
> 
> **Agent-side reporting (no token in the agent process):** Terminal harnesses are told to print **`__SUBTEXT_TELEMETRY__`** JSON lines; **`telemetry-marker.ts`** allowlists steps/metadata, Codex/Gemini pipe stdout through a filter, and Claude Code strips markers from stream-json. The wizard dedupes one event per step and stamps **`harness`**. GUI handoffs run **`guidePluginSetup()`** first; with the plugin, the prompt uses **`telemetry-event` MCP** (agent logs **`start`** with model); without it, the wizard logs **`start`** only to avoid double-counting.
> 
> **Prompt assembly** picks **`mcp` | `stdout` | `none`** telemetry sections (shared step table); **`--print-prompt`** always uses interactive + no agent telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa52561d90d615444e27b77c52daecdfa362ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->