### PR TITLE
docs: rewrite README as a user-facing front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,48 @@
-# @subtextdev/subtext-wizard
+# Subtext setup wizard
 
-One-command onboarding for Subtext session capture:
+**Session replay, built for agents.** [Subtext](https://github.com/fullstorydev/subtext) is agentic session review: it captures production sessions of your app and connects them to your coding agent, so it can review what real users did, reproduce reported bugs, and verify its own UI changes.
+
+This wizard is the fastest way to set that up. One command, run in your project directory:
 
 ```sh
 npx @subtextdev/subtext-wizard
 ```
 
-Previously users copied a long setup prompt into their coding agent by hand. This CLI replaces that: it authenticates the user, fetches their org-specific capture snippet, asks which analytics tools to integrate with, then hands the install to **the user's own coding agent** — we never bundle or provide one.
+**Requires a free Subtext account — no credit card.** Subtext is a hosted service that records and stores your app's sessions. Your account is where they live, and where your agent reads them from. When the wizard opens the login page, create an account in one click with Google, then come back to finish.
 
 ## What it does
 
-1. **Login** — real OAuth 2.1 against production `auth.fullstory.com` (heimdall): dynamic client registration (RFC 7591), authorization-code + PKCE, loopback redirect on `127.0.0.1`. The access-token JWT carries `org_id` and the user's email, so no extra lookup is needed.
-2. **Snippet fetch** — calls the public snippet service (`GET api.fullstory.com/code/v2/snippet?org=…&type=CORE`) with realm-aware hosts and wraps the result in a `<script>` tag.
-3. **Integration selection** — multiselect of PostHog, Amplitude, Mixpanel, Statsig, Sentry, LogRocket, Datadog, LaunchDarkly, GrowthBook, Intercom, Pendo, Appcues, Userpilot, Sprig, Segment, plus free-text "Other". The choices tailor the detection and linkage steps of the install prompt.
-4. **Agent detection** — finds coding agents installed on the machine and asks which to use.
-5. **Handoff** — assembles the install prompt and runs it on the chosen agent:
+1. **Signs you in** — opens Subtext in your browser to log in or create your free account.
+2. **Fetches your capture snippet** — grabs the session-capture snippet for your org.
+3. **Asks about your stack** — pick the analytics and product tools you use (PostHog, Amplitude, Mixpanel, Sentry, Segment, and more) so setup can link them up.
+4. **Finds your coding agent** — detects Claude Code, Codex, Gemini CLI, Cursor, Windsurf, VS Code, Zed, or Claude Desktop.
+5. **Hands the install to your own agent** — no bundled agent; it drives the one you already use to wire up the capture snippet, MCP server, skills, and commands.
 
-| Agent | Kind | Behavior |
-|---|---|---|
-| Claude Code | terminal | Runs headless in the same terminal (`claude -p`, prompt on stdin, `--permission-mode acceptEdits`, streamed `stream-json` progress) |
-| Codex CLI | terminal | Runs headless (`codex exec --full-auto`) |
-| Gemini CLI | terminal | Runs headless (`gemini --yolo -p`) |
-| Cursor / Windsurf / VS Code / Zed | app | Copies the prompt to the clipboard, opens the app at the project folder, shows paste instructions |
-| Claude Desktop | app | Copies the prompt, opens the app, shows paste instructions |
-| None detected | — | Copies the prompt to the clipboard / prints it |
+When it finishes, your agent is connected to your sessions. See the [Subtext repo](https://github.com/fullstorydev/subtext) for what it can do from there.
 
-Terminal agents get the **headless** prompt variant (approval gates replaced with "use best judgment + write `subtext-setup-report.md`"). App handoffs get the **interactive** variant, which keeps every plan/identity/privacy approval gate from the original onboarding prompt.
-
-## Telemetry
-
-Two layers, both fire-and-forget and disabled by `--no-telemetry`:
-
-- **CLI events** (`src/telemetry.ts`) — `wizard_started`, `auth_completed`, `integrations_selected`, `agents_detected`, `agent_launch_started`, `wizard_completed`, `wizard_error`, correlated by a per-run `run_id`.
-- **Agent-side checkpoints** — the prompt itself instructs the agent to `curl` a background ping after each install step, tagged with the same `run_id`, so progress is visible even during the agent-led portion.
-
-## Endpoints
-
-Auth and snippet use **real production endpoints**:
-
-- `https://auth.fullstory.com/oauth/{register,authorize,token}` — OAuth 2.1, PKCE public client, loopback redirect
-- `https://api.fullstory.com/code/v2/snippet?org=…&type=CORE` — public org snippet (`api.eu1.…` for EU orgs)
-- `https://telemetry.subtext.fullstory.com/v1/wizard-events` — **PLACEHOLDER**, no backend yet
-
-Overridable via env vars (`SUBTEXT_AUTH_BASE_URL`, `SUBTEXT_API_BASE_URL`, `SUBTEXT_TELEMETRY_URL`, `SUBTEXT_OAUTH_CLIENT_ID`, `SUBTEXT_OAUTH_SCOPES`). Use `--mock` to run the whole flow offline with canned auth and the example snippet. Remaining backend work: pre-registered OAuth client, scope decision, telemetry ingest, org-aware snippet for custom-host orgs.
-
-## Flags
+## Options
 
 ```
---dir <path>            App directory to instrument (default: cwd)
+--dir <path>            App directory to instrument (default: current directory)
 --region <us|eu>        Data region for login and API hosts (default: us)
---api-key <key>         Skip browser login (OAuth access tokens only)
+--api-key <key>         Skip the browser login and use this access token
 --agent <id>            Skip the agent picker (claude-code, codex, gemini, cursor,
                         windsurf, vscode, zed, claude-desktop, manual)
---integrations <list>   Skip the multiselect (unknown names become "Other")
---print-prompt          Print the assembled prompt instead of launching
---mock                  No network calls
---no-telemetry          Disable telemetry
+--integrations <list>   Comma-separated tools to target, skips the picker
+--print-prompt          Print the install prompt instead of launching an agent
+--no-telemetry          Disable usage telemetry
 --debug                 Verbose output
+--help                  Show all options
 ```
 
-Example end-to-end dry run:
-
-```sh
-node dist/bin.js --mock --print-prompt --integrations "posthog,sentry" --agent claude-code
-```
+EU org? Add `--region eu`.
 
 ## Development
 
+Requires Node 18.17+.
+
 ```sh
 npm install
-npm run build      # tsc → dist/
-node dist/bin.js --mock
-```
-
-Layout:
-
-```
-templates/install-prompt.md   The onboarding prompt, with {{PLACEHOLDER}} slots
-templates/mock-snippet.html   Example snippet returned in --mock mode
-src/bin.ts                    CLI entry + arg parsing
-src/run.ts                    Wizard orchestration
-src/auth.ts                   OAuth PKCE + loopback browser login
-src/snippet.ts                Org snippet fetch (public snippet service)
-src/integrations.ts           Integration catalog + multiselect
-src/prompt/build.ts           Prompt assembly (headless vs interactive variants)
-src/agents/                   Agent detection + launch strategies
-src/telemetry.ts              Fire-and-forget event reporting
+npm run build             # tsc → dist/
+node dist/bin.js --mock   # run the full flow with no network calls
 ```


### PR DESCRIPTION
## What

Rewrites `README.md` so it reads as a front door for someone deciding whether to run the wizard, not as internal build notes. Companion to the main [subtext README refresh](https://github.com/fullstorydev/subtext/pull/10).

**Removed** (internal detail / agent context a user doesn't need):
- The "used to be a long setup prompt, now it's a CLI" origin story.
- OAuth internals (heimdall, RFC 7591 dynamic registration, PKCE, loopback redirect, JWT `org_id`).
- Snippet-fetch internals (the `code/v2/snippet` URL, realm-aware hosts).
- The agent-handoff behavior table (headless vs interactive prompt variants, `claude -p`, `--permission-mode`, `stream-json`, clipboard mechanics), replaced with the user-facing point: it drives your *own* agent rather than bundling one.
- The Telemetry section (event names, `run_id` correlation) — reduced to the `--no-telemetry` flag.
- The Endpoints section, including the `PLACEHOLDER, no backend yet` note and the **"Remaining backend work"** roadmap.
- The file-tree layout.

**Added / kept:**
- Subtext positioning brought over from the main README ("Session replay, built for agents," "agentic session review," "production sessions," the "free Subtext account — no credit card" explainer, one-click Google flow).
- Links back to the Subtext repo so the two front doors point at each other.
- A trimmed flags reference and a short Development section (`--mock` moved there as a dev flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or API behavior affected.
> 
> **Overview**
> Rewrites **`README.md`** from internal build notes into a **user-facing onboarding page** aligned with the main Subtext repo messaging.
> 
> **Removed** deep implementation detail: OAuth/PKCE/heimdall, snippet API URLs, the agent handoff table (headless vs clipboard), the full **Telemetry** and **Endpoints** sections (including backend roadmap), file-tree layout, and the old “long prompt → CLI” origin story.
> 
> **Added** concise product positioning (“session replay, built for agents”), free-account/Google sign-in guidance, a five-step “what it does” flow, cross-links to the Subtext repo, a trimmed **Options** flag list (with clearer `--no-telemetry` wording), and a short **Development** section (`--mock` documented there instead of as a primary user flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2ef50da0c872d5ed31a10b59bdfb23bfd6b69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->