### PR TITLE
adding account creation questionare

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,20 @@ export function apiBaseUrl(region: Region): string {
   return region === 'eu' ? 'https://api.eu1.fullstory.com' : 'https://api.fullstory.com';
 }
 
+/** App frontend host, realm-aware. Hosts the signed-in UI and signup pages. */
+export function appBaseUrl(region: Region): string {
+  if (process.env.SUBTEXT_APP_BASE_URL) return process.env.SUBTEXT_APP_BASE_URL;
+  return region === 'eu' ? 'https://app.eu1.fullstory.com' : 'https://app.fullstory.com';
+}
+
+/**
+ * TEMPORARY: the Subtext-themed account creation page (webber
+ * `/subtext/signup`). Used to hand new users an account before the OAuth
+ * login below — remove once OAuth-native signup lands and drop the offer in
+ * run.ts with it.
+ */
+export const SUBTEXT_SIGNUP_PATH = '/subtext/signup';
+
 /** Capture hosts baked into the snippet, realm-aware. */
 export function captureHosts(region: Region): { host: string; script: string } {
   return region === 'eu'

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,10 +1,11 @@
 import * as p from '@clack/prompts';
 import clipboard from 'clipboardy';
+import open from 'open';
 import pc from 'picocolors';
 import { authenticate } from './auth.js';
 import { chooseAgent, detectAgents, MANUAL_CHOICE } from './agents/index.js';
 import type { WizardOptions } from './config.js';
-import { WIZARD_VERSION, telemetryUrl } from './config.js';
+import { WIZARD_VERSION, appBaseUrl, SUBTEXT_SIGNUP_PATH, telemetryUrl } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
 import { guidePluginSetup } from './plugin.js';
@@ -30,6 +31,37 @@ export async function runWizard(options: WizardOptions): Promise<number> {
   telemetry.note('wizard_started', { mock: options.mock, dir_provided: options.dir !== process.cwd() });
 
   try {
+    // 0. TEMPORARY (until OAuth-native signup lands): offer account creation.
+    //    New users have no org yet, so the OAuth login below would dead-end —
+    //    send them to the Subtext signup page first, then continue into login
+    //    once they confirm they're done. A pre-supplied token already implies
+    //    an account, so skip the offer entirely there. Remove this whole block
+    //    (and SUBTEXT_SIGNUP_PATH) when signup is part of the OAuth flow.
+    if (!options.apiKey) {
+      const needsAccount = await p.confirm({
+        message: 'Do you need to create a new Subtext account?',
+        initialValue: true,
+      });
+      if (p.isCancel(needsAccount)) throw new CancelledError();
+      if (needsAccount) {
+        const signupUrl = `${appBaseUrl(options.region)}${SUBTEXT_SIGNUP_PATH}`;
+        p.log.step('Opening the Subtext account creation page in your browser.');
+        p.log.info(`If it doesn't open, visit:\n${pc.cyan(signupUrl)}`);
+        if (!options.mock) {
+          try {
+            await open(signupUrl);
+          } catch {
+            // URL is printed above; the user can open it manually.
+          }
+        }
+        const created = await p.confirm({
+          message: 'Did you finish creating your account? Continue to log in.',
+        });
+        if (p.isCancel(created) || !created) throw new CancelledError();
+      }
+      telemetry.note('account_creation_offered', { needed: needsAccount });
+    }
+
     // 1. Login (browser flow) so we can fetch the org-specific snippet.
     const auth = await authenticate(options);
 


### PR DESCRIPTION
- this PR adds a temporary account creation redirect for Subtext as we await oauth backend changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only UX with no auth or snippet logic changes; pre-token flows gain an extra prompt and external browser open.
> 
> **Overview**
> Adds a **temporary** onboarding step before browser OAuth for users who do not pass `--api-key`, so new installs are not steered straight into login without an org.
> 
> The wizard asks whether a new Subtext account is needed. If yes, it builds a realm-aware URL via new `appBaseUrl()` and `SUBTEXT_SIGNUP_PATH` (`/subtext/signup`), prints it, and opens the browser with `open` (skipped in mock mode). The user must confirm signup finished before the existing `authenticate()` flow runs; declining or canceling ends the wizard. An `account_creation_offered` telemetry note records whether they chose signup.
> 
> `SUBTEXT_APP_BASE_URL` overrides the app host, consistent with other Subtext env overrides. Comments mark this block for removal once OAuth-native signup exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd21e404c42122f3b01c4e57ba765849136a4c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->