### PR TITLE
disabling eu for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ When it finishes, your agent is connected to your sessions. See the [Subtext rep
 
 ```
 --dir <path>            App directory to instrument (default: current directory)
---region <us|eu>        Data region for login and API hosts (default: us)
 --api-key <key>         Skip the browser login and use this access token
 --agent <id>            Skip the agent picker (claude-code, codex, gemini, cursor,
                         windsurf, vscode, zed, claude-desktop, manual)
@@ -35,8 +34,6 @@ When it finishes, your agent is connected to your sessions. See the [Subtext rep
 --debug                 Verbose output
 --help                  Show all options
 ```
-
-EU org? Add `--region eu`.
 
 ## Development
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -12,7 +12,6 @@ Usage:
 
 Options:
   --dir <path>            App directory to instrument (default: current directory)
-  --region <us|eu>        Data region for login and API hosts (default: us)
   --api-key <key>         Skip the browser login and use this OAuth access token
   --agent <id>            Skip the agent picker (claude-code, codex, gemini, cursor,
                           windsurf, vscode, zed, claude-desktop, manual)
@@ -34,7 +33,6 @@ function main(): void {
     parsed = parseArgs({
       options: {
         dir: { type: 'string' },
-        region: { type: 'string', default: 'us' },
         'api-key': { type: 'string' },
         agent: { type: 'string' },
         integrations: { type: 'string' },
@@ -69,14 +67,11 @@ function main(): void {
     process.exit(1);
   }
 
-  if (values.region !== 'us' && values.region !== 'eu') {
-    console.error(`--region must be 'us' or 'eu', got '${values.region}'.`);
-    process.exit(2);
-  }
-
   const options: WizardOptions = {
     dir: path.resolve(values.dir ?? process.cwd()),
-    region: values.region,
+    // EU is not supported yet; default to the US region. The --region flag is
+    // intentionally not exposed until EU support ships.
+    region: 'us',
     apiKey: values['api-key'],
     agent: values.agent,
     integrations: values.integrations


### PR DESCRIPTION
- this pr disables the EU flag for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI surface change with a fixed US default; no auth or data-path logic beyond dropping the EU override.
> 
> **Overview**
> **Temporarily disables EU region selection** for the Subtext setup wizard by removing the `--region` flag from the CLI, help text, and README, and **hardcoding `region: 'us'`** when building `WizardOptions`.
> 
> Users who previously passed `--region eu` can no longer do so; validation for `us`/`eu` on that flag is removed. Internal `Region` types and EU host helpers in config are unchanged—only the user-facing entry point is pinned to US.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1aae1d91007bed5ffd429adee63b6b826621dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->