### PR TITLE
Nathan/plugin setup

### DIFF
--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -1,0 +1,647 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { runTerminalAgent } from './agents/helpers.js';
+import { MANUAL_CHOICE } from './agents/index.js';
+import type { DetectedAgent } from './agents/types.js';
+import type { Region, WizardOptions } from './config.js';
+import { subtextMcpUrl } from './plugin.js';
+
+/**
+ * Post-install plugin setup. Once the coding agent has run (or been handed)
+ * the install prompt, wire Subtext into that same harness so it can review
+ * captured sessions in later conversations.
+ *
+ * The packaged plugin is preferred wherever one exists, because it bundles
+ * more than the MCP server (skills for Claude Code, both realm servers for
+ * Gemini): Claude Code and Gemini CLI install it via their own CLIs, Cursor
+ * via the official /add-plugin. Harnesses without a plugin get the raw MCP
+ * server entry written straight into their own config file — tools only,
+ * no agent commands involved. Harnesses without a file we can safely edit
+ * (Zed, Claude Desktop, unknown) get instructions instead, as do declines
+ * and unparseable configs.
+ */
+
+/** The plugin repo: Claude Code marketplace and Gemini extension
+ * (gemini-extension.json) in one. */
+export const PLUGIN_REPO_URL = 'https://github.com/fullstorydev/subtext';
+export const PLUGIN_SPEC = 'subtext@subtext-marketplace';
+
+const WHY_PLUGIN =
+  'The Subtext plugin gives your coding agent tools and skills to replay and review the sessions you just set up capturing.';
+
+/** The generic MCP server entry, for harnesses without a specific format. */
+export function manualMcpConfig(region: Region): string {
+  return JSON.stringify(
+    { mcpServers: { subtext: { type: 'http', url: subtextMcpUrl(region) } } },
+    null,
+    2,
+  );
+}
+
+function indent(block: string): string[] {
+  return block.split('\n').map((line) => `  ${line}`);
+}
+
+function prettyPath(file: string): string {
+  const home = os.homedir();
+  if (file === home) return '~';
+  return file.startsWith(home + path.sep) ? `~${file.slice(home.length)}` : file;
+}
+
+// ---------------------------------------------------------------------------
+// Direct config writes
+// ---------------------------------------------------------------------------
+
+type WriteOutcome = 'written' | 'unchanged' | 'unparseable';
+
+interface ConfigWrite {
+  /** Config file the server entry goes into. */
+  file: string;
+  write(): Promise<WriteOutcome>;
+  /** Remove a subtext entry this wizard previously wrote — recognized by
+   * its URL pointing at one of our realm endpoints, so a user's custom
+   * entry is left alone. Used when a packaged plugin supersedes a raw
+   * fallback entry from an earlier run. Returns whether it removed one. */
+  removeOurs?(): Promise<boolean>;
+}
+
+/** Both realm endpoints — used to recognize entries we wrote. */
+function subtextUrls(): string[] {
+  return [subtextMcpUrl('us'), subtextMcpUrl('eu')];
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Merge `{ [section]: { subtext: entry } }` into a JSON config file,
+ * creating the file (and parent dirs) if needed. Never clobbers a file it
+ * can't parse or merge into — JSONC configs with comments, or files where
+ * the root or section isn't an object, fall back to instructions.
+ */
+function jsonConfigWrite(
+  file: string,
+  section: string,
+  entry: JsonObject,
+): ConfigWrite {
+  return {
+    file,
+    async write() {
+      let config: JsonObject = {};
+      try {
+        const parsed: unknown = JSON.parse(await fs.readFile(file, 'utf8'));
+        if (!isPlainObject(parsed)) return 'unparseable';
+        config = parsed;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
+      }
+      if (config[section] != null && !isPlainObject(config[section])) return 'unparseable';
+      const servers = (config[section] ??= {}) as JsonObject;
+      // Merge on top of an existing entry so user extras (headers, disabled,
+      // timeouts…) survive a re-run, but drop competing transport fields we
+      // aren't setting — e.g. a deprecated httpUrl next to the new url.
+      const merged: JsonObject = {
+        ...(isPlainObject(servers.subtext) ? servers.subtext : {}),
+        ...entry,
+      };
+      for (const key of ['url', 'httpUrl', 'serverUrl', 'type', 'transport', 'command', 'args']) {
+        if (!(key in entry)) delete merged[key];
+      }
+      if (JSON.stringify(servers.subtext) === JSON.stringify(merged)) return 'unchanged';
+      servers.subtext = merged;
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+      return 'written';
+    },
+    async removeOurs() {
+      let config: JsonObject;
+      try {
+        const parsed: unknown = JSON.parse(await fs.readFile(file, 'utf8'));
+        if (!isPlainObject(parsed)) return false;
+        config = parsed;
+      } catch {
+        return false;
+      }
+      const servers = config[section];
+      if (!isPlainObject(servers) || !isPlainObject(servers.subtext)) return false;
+      const { url, httpUrl, serverUrl } = servers.subtext;
+      const endpoint = [url, httpUrl, serverUrl].find(
+        (v): v is string => typeof v === 'string',
+      );
+      if (!endpoint || !subtextUrls().includes(endpoint)) return false;
+      delete servers.subtext;
+      await fs.writeFile(file, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+      return true;
+    },
+  };
+}
+
+/**
+ * Codex config is TOML, which we don't parse — append the server table if
+ * it isn't there yet. When the table already exists, rewrite just its
+ * `url` line so a realm change on a re-run doesn't leave a stale host;
+ * a table we can't find the url in falls back to instructions.
+ */
+function codexConfigWrite(file: string, url: string): ConfigWrite {
+  return {
+    file,
+    async write() {
+      let existing = '';
+      try {
+        existing = await fs.readFile(file, 'utf8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return 'unparseable';
+      }
+      // Line-anchored so the header inside a comment or string doesn't
+      // count; tolerates CRLF line endings.
+      const headerRe = /^[ \t]*\[mcp_servers\.subtext\][ \t]*(?:#.*)?\r?$/m;
+      const headerMatch = headerRe.exec(existing);
+      if (headerMatch) {
+        const tableStart = headerMatch.index + headerMatch[0].length;
+        const nextTableRe = /\n[ \t]*\[/g;
+        nextTableRe.lastIndex = tableStart;
+        const nextTable = nextTableRe.exec(existing);
+        const tableEnd = nextTable ? nextTable.index : existing.length;
+        const table = existing.slice(tableStart, tableEnd);
+        const urlLine = /^(\s*url\s*=\s*)"[^"]*"/m;
+        if (!urlLine.test(table)) return 'unparseable';
+        const updated = table.replace(urlLine, (_, prefix: string) => `${prefix}"${url}"`);
+        if (updated === table) return 'unchanged';
+        await fs.writeFile(
+          file,
+          existing.slice(0, tableStart) + updated + existing.slice(tableEnd),
+          'utf8',
+        );
+        return 'written';
+      }
+      const block = `${existing && !existing.endsWith('\n') ? '\n' : ''}${
+        existing ? '\n' : ''
+      }[mcp_servers.subtext]\nurl = "${url}"\n`;
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, existing + block, 'utf8');
+      return 'written';
+    },
+  };
+}
+
+/**
+ * The MCP config file each harness reads, in its own format. Project-scoped
+ * where the harness supports it (the server rides along with the repo);
+ * user-global otherwise. Returns null when there's no file we can safely
+ * edit — those harnesses get instructions. Cursor is deliberately absent:
+ * its packaged plugin (/add-plugin subtext) is the primary route, so it
+ * goes through instructions rather than a config write. Claude Code and
+ * Gemini entries are the fallbacks behind their packaged plugin installs.
+ */
+function configWrite(agentId: string, dir: string, region: Region): ConfigWrite | null {
+  const url = subtextMcpUrl(region);
+  const home = os.homedir();
+  switch (agentId) {
+    case 'claude-code':
+      return jsonConfigWrite(path.join(dir, '.mcp.json'), 'mcpServers', { type: 'http', url });
+    case 'vscode':
+      return jsonConfigWrite(path.join(dir, '.vscode', 'mcp.json'), 'servers', {
+        type: 'http',
+        url,
+      });
+    case 'gemini':
+      // `url` + explicit `type` is the consolidated schema (the old
+      // `httpUrl` field is deprecated, kept only as a compat fallback).
+      return jsonConfigWrite(path.join(home, '.gemini', 'settings.json'), 'mcpServers', {
+        url,
+        type: 'http',
+      });
+    case 'windsurf':
+      // Cascade reads ~/.codeium/windsurf/mcp_config.json.
+      return jsonConfigWrite(
+        path.join(home, '.codeium', 'windsurf', 'mcp_config.json'),
+        'mcpServers',
+        { serverUrl: url },
+      );
+    case 'codex':
+      return codexConfigWrite(path.join(home, '.codex', 'config.toml'), url);
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Instruction fallbacks
+// ---------------------------------------------------------------------------
+
+/** Harness-specific instructions for adding the plugin/server by hand. */
+function pluginInstructions(agentId: string, region: Region): string[] {
+  const url = subtextMcpUrl(region);
+  switch (agentId) {
+    case 'claude-code':
+      return [
+        'In a Claude Code session, run (installs tools + skills):',
+        `  /plugin marketplace add ${PLUGIN_REPO_URL}`,
+        `  /plugin install ${PLUGIN_SPEC}`,
+        '',
+        'Prefer a raw MCP server (tools only)? Add this to .mcp.json in the project:',
+        ...indent(manualMcpConfig(region)),
+      ];
+    case 'cursor':
+      return [
+        'In Cursor, run this in the agent pane (installs tools + skills):',
+        '  /add-plugin subtext',
+        '',
+        'Prefer a raw MCP server (tools only)? Add this to .cursor/mcp.json in the project:',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { url } } }, null, 2)),
+      ];
+    case 'gemini':
+      return [
+        'Install the Subtext extension (bundles the MCP servers):',
+        `  gemini extensions install ${PLUGIN_REPO_URL}`,
+        '',
+        'Prefer a raw MCP server? Add this to ~/.gemini/settings.json:',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { url, type: 'http' } } }, null, 2)),
+      ];
+    case 'windsurf':
+      return [
+        'Add this to ~/.codeium/windsurf/mcp_config.json (read by Cascade in Windsurf):',
+        ...indent(JSON.stringify({ mcpServers: { subtext: { serverUrl: url } } }, null, 2)),
+      ];
+    case 'claude-desktop':
+      return [
+        'In Claude Desktop: Settings → Connectors → Add custom connector,',
+        `then enter: ${url}`,
+      ];
+    case 'codex':
+      return [
+        'Add the Subtext MCP server to ~/.codex/config.toml:',
+        '  [mcp_servers.subtext]',
+        `  url = "${url}"`,
+      ];
+    case 'vscode':
+      return [
+        'Add the Subtext MCP server to .vscode/mcp.json in this project:',
+        ...indent(JSON.stringify({ servers: { subtext: { type: 'http', url } } }, null, 2)),
+      ];
+    default:
+      return [
+        `Add an MCP server named 'subtext' in your agent's MCP settings:`,
+        ...indent(manualMcpConfig(region)),
+      ];
+  }
+}
+
+/** Shown when the user took the raw prompt — we don't know their harness. */
+function manualChoiceInstructions(region: Region): string[] {
+  return [
+    'Claude Code — run in a session (installs tools + skills):',
+    `  /plugin marketplace add ${PLUGIN_REPO_URL}`,
+    `  /plugin install ${PLUGIN_SPEC}`,
+    '',
+    'Cursor — run in the agent pane (installs tools + skills):',
+    '  /add-plugin subtext',
+    '',
+    'Gemini CLI — install the extension:',
+    `  gemini extensions install ${PLUGIN_REPO_URL}`,
+    '',
+    'Any other MCP-capable agent — add this server config (tools only):',
+    ...indent(manualMcpConfig(region)),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Packaged plugin installs
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `claude plugin marketplace add` + `claude plugin install`. The
+ * marketplace add is soft-fail (it errors when the marketplace is already
+ * registered, e.g. on a re-run); the install itself decides success.
+ */
+async function installClaudeCodePlugin(binaryPath: string, cwd: string): Promise<boolean> {
+  const addExit = await runTerminalAgent({
+    binaryPath,
+    args: ['plugin', 'marketplace', 'add', PLUGIN_REPO_URL],
+    cwd,
+    stdout: 'inherit',
+  });
+  if (addExit !== 0) {
+    p.log.info(pc.dim('Marketplace add failed — it may already be registered; continuing.'));
+  }
+  const installExit = await runTerminalAgent({
+    binaryPath,
+    args: ['plugin', 'install', PLUGIN_SPEC],
+    cwd,
+    stdout: 'inherit',
+  });
+  return installExit === 0;
+}
+
+interface PackagedPlugin {
+  /** Confirm-prompt fragment describing what the install brings. */
+  confirmHint: string;
+  /** The commands install() runs, for mock-mode display. */
+  commands: string[];
+  /** Fast local check for an existing install, so re-runs don't fall back
+   * into writing a duplicate raw server entry. */
+  alreadyInstalled(): Promise<boolean>;
+  install(): Promise<boolean>;
+}
+
+/** The scriptable plugin install for this harness, if it has one. */
+function packagedPlugin(chosen: DetectedAgent, options: WizardOptions): PackagedPlugin | null {
+  const { binaryPath } = chosen;
+  if (!binaryPath) return null;
+  switch (chosen.definition.id) {
+    case 'claude-code':
+      return {
+        confirmHint: 'session-review tools plus the proof/review skills',
+        commands: [
+          `claude plugin marketplace add ${PLUGIN_REPO_URL}`,
+          `claude plugin install ${PLUGIN_SPEC}`,
+        ],
+        // `claude plugin install` records installs in installed_plugins.json,
+        // keyed by <plugin>@<marketplace> — the same spec we install. A
+        // user-scoped install applies everywhere; project/local ones only
+        // count when they're for the directory being instrumented.
+        alreadyInstalled: async () => {
+          try {
+            const installed = JSON.parse(
+              await fs.readFile(
+                path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json'),
+                'utf8',
+              ),
+            ) as { plugins?: Record<string, unknown> };
+            const entries = installed.plugins?.[PLUGIN_SPEC];
+            if (!Array.isArray(entries)) return false;
+            return entries.some(
+              (entry) =>
+                isPlainObject(entry) &&
+                (entry.scope === 'user' ||
+                  (typeof entry.projectPath === 'string' &&
+                    path.resolve(entry.projectPath) === path.resolve(options.dir))),
+            );
+          } catch {
+            return false;
+          }
+        },
+        install: () => installClaudeCodePlugin(binaryPath, options.dir),
+      };
+    case 'gemini':
+      return {
+        confirmHint: 'installs the Subtext extension with its MCP servers',
+        commands: [`gemini extensions install ${PLUGIN_REPO_URL}`],
+        alreadyInstalled: async () => {
+          try {
+            await fs.access(path.join(os.homedir(), '.gemini', 'extensions', 'subtext'));
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        install: async () =>
+          (await runTerminalAgent({
+            binaryPath,
+            args: ['extensions', 'install', PLUGIN_REPO_URL],
+            cwd: options.dir,
+            stdout: 'inherit',
+          })) === 0,
+      };
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The wizard step
+// ---------------------------------------------------------------------------
+
+/** Write the raw server entry and report; instructions if the file resists. */
+async function applyConfigWrite(
+  target: ConfigWrite,
+  agentId: string,
+  agentName: string,
+  region: Region,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+  method: string,
+): Promise<void> {
+  const shownPath = prettyPath(target.file);
+  let outcome: WriteOutcome;
+  try {
+    outcome = await target.write();
+  } catch {
+    outcome = 'unparseable';
+  }
+  if (outcome === 'unparseable') {
+    onEvent('plugin_setup_failed', { agent: agentId });
+    p.log.warn(`Could not update ${shownPath} — it may have a format we can't merge safely.`);
+    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it by hand');
+    return;
+  }
+  onEvent('plugin_setup_completed', { agent: agentId, method });
+  p.log.success(
+    outcome === 'written'
+      ? `Subtext MCP server added to ${shownPath} — picked up the next time ${agentName} starts here.`
+      : `Subtext MCP server already configured in ${shownPath}.`,
+  );
+}
+
+/**
+ * A working packaged plugin supersedes any raw fallback entry left by an
+ * earlier run — drop it so the harness doesn't load Subtext twice.
+ * Best-effort: only removes an entry whose URL is one of our endpoints.
+ */
+async function removeSupersededRawEntry(
+  agentId: string,
+  dir: string,
+  region: Region,
+): Promise<void> {
+  const target = configWrite(agentId, dir, region);
+  if (!target?.removeOurs) return;
+  try {
+    if (await target.removeOurs()) {
+      p.log.info(
+        pc.dim(
+          `Removed the raw MCP server entry from ${prettyPath(target.file)} — the plugin supersedes it.`,
+        ),
+      );
+    }
+  } catch {
+    // duplicate tools are annoying but not worth failing the step over
+  }
+}
+
+/**
+ * Confirm gate for the plugin prompts. An explicit "No" is a decline —
+ * instructions for later. Ctrl+C / Escape skips the rest of the step
+ * with no further output: unlike the wizard's earlier prompts this is
+ * not a CancelledError, because by now the install itself has already
+ * succeeded and "nothing was changed" / exit 130 would misreport it.
+ */
+async function confirmOrSkip(
+  message: string,
+  agentId: string,
+  region: Region,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+  laterTitle: string,
+): Promise<boolean> {
+  const answer = await p.confirm({ message });
+  if (p.isCancel(answer)) {
+    onEvent('plugin_setup_declined', { agent: agentId, cancelled: true });
+    p.log.info(
+      pc.dim('Plugin setup skipped — run this installer again any time to set it up.'),
+    );
+    return false;
+  }
+  if (!answer) {
+    onEvent('plugin_setup_declined', { agent: agentId });
+    p.note(pluginInstructions(agentId, region).join('\n'), laterTitle);
+    return false;
+  }
+  return true;
+}
+
+/** Packaged plugin path: install via the harness's own CLI, raw entry on failure. */
+async function packagedPluginSetup(
+  plugin: PackagedPlugin,
+  chosen: DetectedAgent,
+  region: Region,
+  options: WizardOptions,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+): Promise<void> {
+  const agentId = chosen.definition.id;
+  const agentName = chosen.definition.name;
+
+  // Check for an existing install before asking anything — a re-run
+  // shouldn't prompt for (or count a decline against) a plugin that's
+  // already there. Skipped in mock mode, which never reads real state.
+  if (!options.mock && (await plugin.alreadyInstalled())) {
+    await removeSupersededRawEntry(agentId, options.dir, region);
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'already-installed' });
+    p.log.success(`Subtext plugin already installed in ${agentName}.`);
+    return;
+  }
+
+  // A pre-selected --agent means "just run it", same as the prompt-review
+  // bypass; otherwise ask before touching the user's harness config.
+  if (
+    !options.agent &&
+    !(await confirmOrSkip(
+      `Install the Subtext plugin in ${agentName}? ${pc.dim(`(${plugin.confirmHint})`)}`,
+      agentId,
+      region,
+      onEvent,
+      'Install it later',
+    ))
+  ) {
+    return;
+  }
+
+  if (options.mock) {
+    p.log.info(
+      pc.dim(`Mock mode: would run\n  ${plugin.commands.join('\n  ')}`),
+    );
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
+    return;
+  }
+
+  p.log.step(`Installing the Subtext plugin in ${agentName}…`);
+  let installed = false;
+  try {
+    installed = await plugin.install();
+  } catch {
+    // fall through to the raw MCP server entry
+  }
+  if (installed) {
+    await removeSupersededRawEntry(agentId, options.dir, region);
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'plugin-cli' });
+    p.log.success(
+      `Subtext plugin installed — available in your next ${agentName} session.`,
+    );
+    return;
+  }
+
+  p.log.warn('Plugin install failed — a raw MCP server entry (tools only) can be added instead.');
+  const target = configWrite(agentId, options.dir, region)!;
+  // The user approved the plugin install, not a config-file edit — ask
+  // again before touching a different file (same --agent bypass as above).
+  if (
+    !options.agent &&
+    !(await confirmOrSkip(
+      `Add the Subtext MCP server to ${prettyPath(target.file)} instead?`,
+      agentId,
+      region,
+      onEvent,
+      'Add it later',
+    ))
+  ) {
+    return;
+  }
+  await applyConfigWrite(target, agentId, agentName, region, onEvent, 'config-write-fallback');
+}
+
+/**
+ * Step 8 of the wizard, after the prompt run: wire Subtext into the harness
+ * that ran the install — packaged plugin where one exists, raw MCP server
+ * entry otherwise. `region` is the org's resolved realm (from the auth
+ * token), not the CLI flag — the MCP URLs written here must match the org.
+ * Never throws — the install already succeeded, so plugin trouble is
+ * reported and the wizard finishes cleanly.
+ */
+export async function offerPluginSetup(
+  chosen: DetectedAgent | typeof MANUAL_CHOICE,
+  region: Region,
+  options: WizardOptions,
+  onEvent: (event: string, properties?: Record<string, unknown>) => void,
+): Promise<void> {
+  const agentId = chosen === MANUAL_CHOICE ? MANUAL_CHOICE : chosen.definition.id;
+  onEvent('plugin_setup_offered', { agent: agentId });
+
+  if (chosen !== MANUAL_CHOICE) {
+    const plugin = packagedPlugin(chosen, options);
+    if (plugin) {
+      await packagedPluginSetup(plugin, chosen, region, options, onEvent);
+      return;
+    }
+  }
+
+  const target = chosen === MANUAL_CHOICE ? null : configWrite(agentId, options.dir, region);
+  if (!target) {
+    // Cursor (plugin route), Zed, Claude Desktop, manual.
+    const lines =
+      chosen === MANUAL_CHOICE
+        ? manualChoiceInstructions(region)
+        : pluginInstructions(agentId, region);
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'instructions' });
+    p.note([WHY_PLUGIN, '', ...lines].join('\n'), 'Add the Subtext plugin');
+    return;
+  }
+
+  const agentName = chosen === MANUAL_CHOICE ? 'your agent' : chosen.definition.name;
+  const shownPath = prettyPath(target.file);
+
+  if (
+    !options.agent &&
+    !(await confirmOrSkip(
+      `Add the Subtext MCP server to ${shownPath}? ${pc.dim(
+        `(lets ${agentName} review captured sessions)`,
+      )}`,
+      agentId,
+      region,
+      onEvent,
+      'Add it later',
+    ))
+  ) {
+    return;
+  }
+
+  if (options.mock) {
+    p.log.info(pc.dim(`Mock mode: would add the Subtext MCP server to ${shownPath}.`));
+    onEvent('plugin_setup_completed', { agent: agentId, method: 'mock' });
+    return;
+  }
+
+  await applyConfigWrite(target, agentId, agentName, region, onEvent, 'config-write');
+}

--- a/src/pluginSetup.ts
+++ b/src/pluginSetup.ts
@@ -10,18 +10,18 @@ import type { Region, WizardOptions } from './config.js';
 import { subtextMcpUrl } from './plugin.js';
 
 /**
- * Post-install plugin setup. Once the coding agent has run (or been handed)
- * the install prompt, wire Subtext into that same harness so it can review
- * captured sessions in later conversations.
+ * Post-install plugin setup for terminal harnesses and the manual path.
+ * Once the coding agent has run the install prompt, wire Subtext into that
+ * same harness so it can review captured sessions in later conversations.
+ * GUI apps never reach here — they get plugin.ts's guidePluginSetup before
+ * the handoff, whose outcome also decides telemetry ownership.
  *
- * The packaged plugin is preferred wherever one exists, because it bundles
+ * The packaged plugin is preferred where one exists, because it bundles
  * more than the MCP server (skills for Claude Code, both realm servers for
- * Gemini): Claude Code and Gemini CLI install it via their own CLIs, Cursor
- * via the official /add-plugin. Harnesses without a plugin get the raw MCP
- * server entry written straight into their own config file — tools only,
- * no agent commands involved. Harnesses without a file we can safely edit
- * (Zed, Claude Desktop, unknown) get instructions instead, as do declines
- * and unparseable configs.
+ * Gemini): Claude Code and Gemini CLI install it via their own CLIs.
+ * Harnesses without a plugin get the raw MCP server entry written straight
+ * into their own config file (Codex TOML) — tools only, no agent commands
+ * involved. Declines and unparseable configs get instructions instead.
  */
 
 /** The plugin repo: Claude Code marketplace and Gemini extension
@@ -191,12 +191,10 @@ function codexConfigWrite(file: string, url: string): ConfigWrite {
 }
 
 /**
- * The MCP config file each harness reads, in its own format. Project-scoped
- * where the harness supports it (the server rides along with the repo);
- * user-global otherwise. Returns null when there's no file we can safely
- * edit — those harnesses get instructions. Cursor is deliberately absent:
- * its packaged plugin (/add-plugin subtext) is the primary route, so it
- * goes through instructions rather than a config write. Claude Code and
+ * The MCP config file each terminal harness reads, in its own format.
+ * Project-scoped where the harness supports it (the server rides along with
+ * the repo); user-global otherwise. Returns null when there's no file we
+ * can safely edit — those harnesses get instructions. Claude Code and
  * Gemini entries are the fallbacks behind their packaged plugin installs.
  */
 function configWrite(agentId: string, dir: string, region: Region): ConfigWrite | null {
@@ -205,11 +203,6 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
   switch (agentId) {
     case 'claude-code':
       return jsonConfigWrite(path.join(dir, '.mcp.json'), 'mcpServers', { type: 'http', url });
-    case 'vscode':
-      return jsonConfigWrite(path.join(dir, '.vscode', 'mcp.json'), 'servers', {
-        type: 'http',
-        url,
-      });
     case 'gemini':
       // `url` + explicit `type` is the consolidated schema (the old
       // `httpUrl` field is deprecated, kept only as a compat fallback).
@@ -217,13 +210,6 @@ function configWrite(agentId: string, dir: string, region: Region): ConfigWrite 
         url,
         type: 'http',
       });
-    case 'windsurf':
-      // Cascade reads ~/.codeium/windsurf/mcp_config.json.
-      return jsonConfigWrite(
-        path.join(home, '.codeium', 'windsurf', 'mcp_config.json'),
-        'mcpServers',
-        { serverUrl: url },
-      );
     case 'codex':
       return codexConfigWrite(path.join(home, '.codex', 'config.toml'), url);
     default:
@@ -248,14 +234,6 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         'Prefer a raw MCP server (tools only)? Add this to .mcp.json in the project:',
         ...indent(manualMcpConfig(region)),
       ];
-    case 'cursor':
-      return [
-        'In Cursor, run this in the agent pane (installs tools + skills):',
-        '  /add-plugin subtext',
-        '',
-        'Prefer a raw MCP server (tools only)? Add this to .cursor/mcp.json in the project:',
-        ...indent(JSON.stringify({ mcpServers: { subtext: { url } } }, null, 2)),
-      ];
     case 'gemini':
       return [
         'Install the Subtext extension (bundles the MCP servers):',
@@ -264,26 +242,11 @@ function pluginInstructions(agentId: string, region: Region): string[] {
         'Prefer a raw MCP server? Add this to ~/.gemini/settings.json:',
         ...indent(JSON.stringify({ mcpServers: { subtext: { url, type: 'http' } } }, null, 2)),
       ];
-    case 'windsurf':
-      return [
-        'Add this to ~/.codeium/windsurf/mcp_config.json (read by Cascade in Windsurf):',
-        ...indent(JSON.stringify({ mcpServers: { subtext: { serverUrl: url } } }, null, 2)),
-      ];
-    case 'claude-desktop':
-      return [
-        'In Claude Desktop: Settings → Connectors → Add custom connector,',
-        `then enter: ${url}`,
-      ];
     case 'codex':
       return [
         'Add the Subtext MCP server to ~/.codex/config.toml:',
         '  [mcp_servers.subtext]',
         `  url = "${url}"`,
-      ];
-    case 'vscode':
-      return [
-        'Add the Subtext MCP server to .vscode/mcp.json in this project:',
-        ...indent(JSON.stringify({ servers: { subtext: { type: 'http', url } } }, null, 2)),
       ];
     default:
       return [
@@ -524,10 +487,11 @@ async function packagedPluginSetup(
     return;
   }
 
-  // A pre-selected --agent means "just run it", same as the prompt-review
-  // bypass; otherwise ask before touching the user's harness config.
+  // Only an explicit --yes (CI) skips this — matching the wizard's other
+  // confirm gates. --agent merely preselects the harness; it never
+  // authorizes changes to the user's config.
   if (
-    !options.agent &&
+    !options.yes &&
     !(await confirmOrSkip(
       `Install the Subtext plugin in ${agentName}? ${pc.dim(`(${plugin.confirmHint})`)}`,
       agentId,
@@ -564,11 +528,18 @@ async function packagedPluginSetup(
   }
 
   p.log.warn('Plugin install failed — a raw MCP server entry (tools only) can be added instead.');
-  const target = configWrite(agentId, options.dir, region)!;
+  const target = configWrite(agentId, options.dir, region);
+  if (!target) {
+    // No writable config for this harness — don't crash on an invariant
+    // packagedPlugin() and configWrite() only uphold by convention.
+    onEvent('plugin_setup_failed', { agent: agentId });
+    p.note(pluginInstructions(agentId, region).join('\n'), 'Add it by hand');
+    return;
+  }
   // The user approved the plugin install, not a config-file edit — ask
-  // again before touching a different file (same --agent bypass as above).
+  // again before touching a different file (same --yes bypass as above).
   if (
-    !options.agent &&
+    !options.yes &&
     !(await confirmOrSkip(
       `Add the Subtext MCP server to ${prettyPath(target.file)} instead?`,
       agentId,
@@ -609,7 +580,7 @@ export async function offerPluginSetup(
 
   const target = chosen === MANUAL_CHOICE ? null : configWrite(agentId, options.dir, region);
   if (!target) {
-    // Cursor (plugin route), Zed, Claude Desktop, manual.
+    // Manual path, or a harness with no writable config.
     const lines =
       chosen === MANUAL_CHOICE
         ? manualChoiceInstructions(region)
@@ -623,7 +594,7 @@ export async function offerPluginSetup(
   const shownPath = prettyPath(target.file);
 
   if (
-    !options.agent &&
+    !options.yes &&
     !(await confirmOrSkip(
       `Add the Subtext MCP server to ${shownPath}? ${pc.dim(
         `(lets ${agentName} review captured sessions)`,

--- a/src/promptReview.ts
+++ b/src/promptReview.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import * as p from '@clack/prompts';
+import open from 'open';
+import pc from 'picocolors';
+import { CancelledError } from './integrations.js';
+
+/**
+ * Pre-handoff transparency gate: the install prompt is what the coding agent
+ * actually executes, so the user gets to read it before anything runs. The
+ * prompt is served on a localhost one-shot page (same loopback pattern as the
+ * OAuth callback) and opened in the browser; if that fails it lands in a temp
+ * file instead. Either way the wizard re-confirms before proceeding.
+ */
+
+export interface PromptReviewChoices {
+  /** Select-option label and confirm message for proceeding (e.g. "Run the install now with Claude Code"). */
+  proceedLabel: string;
+  /** Optional hint shown next to the proceed option (e.g. "edits files in /app, auto-accepting"). */
+  proceedHint?: string;
+}
+
+export async function offerPromptReview(
+  prompt: string,
+  { proceedLabel, proceedHint }: PromptReviewChoices,
+): Promise<{ reviewed: boolean }> {
+  const lineCount = prompt.split('\n').length;
+  const choice = await p.select({
+    message: `The install prompt is ready (${lineCount} lines) — it tells your coding agent exactly what to do.`,
+    options: [
+      { value: 'proceed', label: proceedLabel, hint: proceedHint },
+      { value: 'review', label: 'Review the prompt first', hint: 'opens in your browser' },
+      { value: 'cancel', label: 'Cancel' },
+    ],
+  });
+  if (p.isCancel(choice) || choice === 'cancel') {
+    throw new CancelledError();
+  }
+  if (choice === 'proceed') {
+    return { reviewed: false };
+  }
+
+  let closeServer: (() => void) | undefined;
+  try {
+    const served = await servePromptPage(renderPromptHtml(prompt));
+    closeServer = served.close;
+    p.log.info(`Prompt opened at ${pc.cyan(served.url)} — the page stays up until you answer below.`);
+    try {
+      await open(served.url);
+    } catch {
+      // URL is printed above; the user can open it manually.
+    }
+  } catch {
+    // No server? Fall back to a temp file the user can open themselves.
+    const file = path.join(os.tmpdir(), 'subtext-install-prompt.md');
+    await fs.writeFile(file, prompt, 'utf8');
+    p.log.info(`Could not open a browser — the prompt is saved at ${pc.cyan(file)}`);
+  }
+
+  const confirmed = await p.confirm({ message: `${proceedLabel}?` });
+  closeServer?.();
+  if (p.isCancel(confirmed) || !confirmed) {
+    throw new CancelledError();
+  }
+  return { reviewed: true };
+}
+
+/** Serves a single HTML page on an ephemeral loopback port. */
+export async function servePromptPage(html: string): Promise<{ url: string; close: () => void }> {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    if (url.pathname !== '/') {
+      res.writeHead(404).end();
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(html);
+  });
+  // unref: the server must never be the thing keeping the process alive —
+  // if the wizard exits, the page dies with it.
+  server.unref();
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  return { url: `http://127.0.0.1:${port}/`, close: () => server.close() };
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function renderPromptHtml(prompt: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Subtext install prompt</title>
+<style>
+  body { margin: 0; background: #0f0d15; color: #e7e2f4; font: 14px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  header { position: sticky; top: 0; background: #171226; border-bottom: 1px solid #2d2540; padding: 14px 24px; font-family: ui-sans-serif, system-ui, sans-serif; }
+  header h1 { margin: 0; font-size: 15px; color: #c4b5fd; }
+  header p { margin: 4px 0 0; font-size: 12.5px; color: #8b83a3; }
+  main { max-width: 920px; margin: 0 auto; padding: 24px; }
+  pre { white-space: pre-wrap; overflow-wrap: break-word; margin: 0; }
+</style>
+</head>
+<body>
+<header>
+  <h1>subtext &middot; install prompt</h1>
+  <p>This is the exact prompt the installer will hand to your coding agent. Return to your terminal to continue or cancel.</p>
+</header>
+<main><pre>${escapeHtml(prompt)}</pre></main>
+</body>
+</html>
+`;
+}

--- a/src/promptReview.ts
+++ b/src/promptReview.ts
@@ -54,10 +54,17 @@ export async function offerPromptReview(
       // URL is printed above; the user can open it manually.
     }
   } catch {
-    // No server? Fall back to a temp file the user can open themselves.
-    const file = path.join(os.tmpdir(), 'subtext-install-prompt.md');
-    await fs.writeFile(file, prompt, 'utf8');
-    p.log.info(`Could not open a browser — the prompt is saved at ${pc.cyan(file)}`);
+    // No server? Fall back to a temp file the user can open themselves —
+    // and if even that fails, print the prompt inline. The user asked to
+    // READ the prompt; that must never abort the run.
+    try {
+      const file = path.join(os.tmpdir(), 'subtext-install-prompt.md');
+      await fs.writeFile(file, prompt, 'utf8');
+      p.log.info(`Could not open a browser — the prompt is saved at ${pc.cyan(file)}`);
+    } catch {
+      p.log.warn('Could not open a browser or write a temp file — the prompt is below.');
+      console.log(`\n${prompt}\n`);
+    }
   }
 
   const confirmed = await p.confirm({ message: `${proceedLabel}?` });

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,7 +8,9 @@ import { WIZARD_VERSION, telemetryUrl } from './config.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
 import { guidePluginSetup } from './plugin.js';
+import { offerPluginSetup } from './pluginSetup.js';
 import { buildInstallPrompt, type PromptTelemetry } from './prompt/build.js';
+import { offerPromptReview } from './promptReview.js';
 import { fetchCaptureSnippet } from './snippet.js';
 import { Telemetry } from './telemetry.js';
 
@@ -130,6 +132,24 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       return 0;
     }
 
+    // 6b. Pre-handoff transparency: let the user read the exact prompt the
+    //     agent will execute before anything runs. --yes (CI) skips it; for
+    //     terminal runs the autonomy confirm below remains the authorization.
+    if (!options.yes) {
+      const proceedLabel =
+        chosen === MANUAL_CHOICE
+          ? 'Copy the prompt to my clipboard'
+          : isTerminalRun
+            ? 'Continue'
+            : `Open ${chosen.definition.name} with the install prompt`;
+      const { reviewed } = await offerPromptReview(prompt, {
+        proceedLabel,
+        proceedHint:
+          chosen !== MANUAL_CHOICE && isTerminalRun ? `will run in ${options.dir}` : undefined,
+      });
+      if (reviewed) telemetry.note('prompt_reviewed');
+    }
+
     // 7. Hand off to the agent.
     if (chosen === MANUAL_CHOICE) {
       sendStart('manual');
@@ -150,6 +170,10 @@ export async function runWizard(options: WizardOptions): Promise<number> {
         p.log.warn('Could not write to the clipboard — copy the prompt below.');
         console.log(`\n${prompt}\n`);
       }
+      // Plugin setup — we don't know the harness, so show every path.
+      await offerPluginSetup(MANUAL_CHOICE, auth.region, options, (event, properties) =>
+        telemetry.note(event, properties),
+      );
       p.outro('Run this installer again any time with: npx @subtextdev/subtext-wizard');
       await telemetry.flush();
       return 0;
@@ -228,6 +252,11 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       p.note(result.followUp?.join('\n') ?? '', 'Next steps');
       p.outro('Finish the install in your agent — it will guide you from here.');
     } else if (result.exitCode === 0) {
+      // Terminal install succeeded — wire Subtext into the harness that ran it
+      // (packaged plugin where one exists, raw MCP entry otherwise).
+      await offerPluginSetup(chosen, auth.region, options, (event, properties) =>
+        telemetry.note(event, properties),
+      );
       p.outro(
         'Subtext install finished. Review the changes (and subtext-setup-report.md), then deploy to start capturing sessions.',
       );


### PR DESCRIPTION
Summary

Two additions to the handoff phase of the wizard:

1. Post-run plugin setup for terminal harnesses (src/pluginSetup.ts). After a successful terminal install (Claude Code, Codex, Gemini) — and on the manual path — the wizard wires Subtext into the harness that ran the install, so the agent can review captured sessions in later conversations. Packaged plugin where one exists, raw MCP config entry otherwise.
2. Pre-handoff prompt review (src/promptReview.ts). Before anything runs, the user can read the exact install prompt the agent will execute, served on a one-shot localhost page (same loopback pattern as the OAuth callback), with a temp-file → inline-print fallback chain.

How it composes with main

This is deliberately a hybrid with main's existing flow, not a replacement:

- GUI apps keep plugin.ts's pre-handoff guidePluginSetup — its result decides telemetry ownership (mcp vs wizard-parsed markers), which must be known before the prompt is built. offerPluginSetup therefore only runs for terminal + manual handoffs; no double prompt.
- Main's terminal autonomy confirm is untouched and remains the authorization for autonomous runs; the review step is transparency on top, skipped by --yes.

Plugin setup details

- Claude Code: claude plugin marketplace add + claude plugin install subtext@subtext-marketplace via the detected binary; detects existing installs first (user-scoped, or project-scoped for the target dir) so re-runs don't re-prompt; a working plugin install removes a raw .mcp.json entry a previous run left behind.
- Gemini: installs the packaged extension (gemini extensions install), ~/.gemini/settings.json entry as the fallback.
- Codex: appends/updates [mcp_servers.subtext] in ~/.codex/config.toml, rewriting just the url line on re-run (CRLF-tolerant, comment-safe header match).
- Manual path: prints every option (Claude Code, Cursor, Gemini, generic MCP config).
- Safety: JSON merges refuse non-object roots/sections instead of silently corrupting them; user extras on an existing entry survive re-runs; realm comes from the resolved org (auth.region), not the CLI flag; the step never throws — a failed plugin step reports and lets the wizard finish, since the install itself already succeeded.
- Confirm gates: every mutation (plugin install, config write, fallback write) is confirm-gated; only an explicit --yes skips, consistent with main's hardened --agent-never-authorizes semantics. Cancelling (Ctrl+C) is distinguished from declining — a decline gets "do it later" instructions.

Prompt review details

- Select gate: proceed / review-in-browser / cancel. Reviewing serves the rendered prompt on 127.0.0.1:<ephemeral> and re-confirms before proceeding.
- Fallbacks: no server → temp file; temp file also fails → prompt printed inline. Reading the prompt can never abort the run.
- Skipped with --yes (CI); declining cancels cleanly (CancelledError → exit 130, "nothing was changed").

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The wizard may edit user agent config files and invoke harness CLIs, but changes are gated by confirms, use merge-safe writes keyed to Subtext realm URLs, and failures degrade to instructions without failing the completed install.
> 
> **Overview**
> Adds two wizard steps around the install handoff: users can **read the exact install prompt** before anything runs, and after a successful terminal or manual flow the installer can **wire Subtext into that harness** for later session review.
> 
> **Pre-handoff (`offerPromptReview`)** — Unless `--yes` (CI), the wizard offers proceed, browser review, or cancel. Review serves the prompt on loopback HTML (with temp-file / inline fallbacks) and requires confirmation before continuing; reviewed runs emit `prompt_reviewed` telemetry.
> 
> **Post-install (`offerPluginSetup`)** — After manual clipboard handoff or a successful terminal agent run, the wizard offers packaged plugin installs (Claude Code marketplace + install, Gemini extension) or merges a raw HTTP MCP entry into harness-specific configs (project `.mcp.json`, `~/.gemini/settings.json`, Codex TOML). It respects org **realm** from auth (not the CLI flag), skips duplicate prompts when already installed, removes wizard-owned raw entries when a plugin supersedes them, and falls back to printed instructions on decline or unparseable configs. Plugin steps use confirm gates (`--yes` only bypasses); cancel after install does not throw `CancelledError`. GUI apps still use existing pre-handoff `guidePluginSetup` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3e938627a0b1f73ffafd3208f5e6ff1d536d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->