### PR TITLE
adding first run step at completion

### DIFF
--- a/src/agents/apps.ts
+++ b/src/agents/apps.ts
@@ -81,7 +81,7 @@ function makeAppAgent(spec: AppAgentSpec): AgentDefinition {
         // Make sure the user can still get the prompt.
         p.log.message(ctx.prompt);
       }
-      return { mode: 'handoff', followUp };
+      return { mode: 'handoff', followUp, clipboardHoldsPrompt: copied };
     },
   };
   return definition;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -29,6 +29,9 @@ export interface LaunchResult {
   exitCode?: number;
   /** Instructions to show the user after a handoff. */
   followUp?: string[];
+  /** Handoff only: the install prompt was copied to the clipboard, so later
+   * clipboard offers (the demo prompt) must warn before clobbering it. */
+  clipboardHoldsPrompt?: boolean;
 }
 
 export interface AgentDefinition {

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,0 +1,91 @@
+import * as p from '@clack/prompts';
+import clipboard from 'clipboardy';
+import pc from 'picocolors';
+import { brandPurple } from './logo.js';
+
+/**
+ * The wizard's closing section: a short "see it in action" guide. Capture is
+ * now wired into the app, so the user can watch the loop work end-to-end —
+ * run the local dev server, click around to record a session, then ask the
+ * same agent they just set up to review that session through the Subtext
+ * plugin. Informational plus an optional clipboard copy; it never throws,
+ * because everything before it has already succeeded and a cancel here must
+ * not turn a finished install into a reported failure.
+ */
+
+/** Kept as sentences so the note can show one per line while the clipboard
+ * gets a single line — some terminal agents submit on a pasted newline. */
+const DEMO_PROMPT_LINES = [
+  'I just set up Subtext session capture in this app and clicked around my',
+  'local dev build. Use the Subtext tools to find my most recent captured',
+  'session and walk me through it: which pages I visited, what I interacted',
+  'with, and anything that looked broken or confusing along the way.',
+];
+
+export const DEMO_PROMPT = DEMO_PROMPT_LINES.join(' ');
+
+export interface DemoGuideContext {
+  /** Harness display name ("Claude Code"), or "your coding agent" when the
+   * user took the raw prompt and we never learned which one. */
+  agentName: string;
+  /** True when the install prompt still has to run (manual copy / GUI
+   * handoff) — the guide then leads with "once the install finishes". */
+  installPending: boolean;
+  /** Manual path only: the install prompt currently occupies the clipboard,
+   * so copying the demo prompt now would clobber it. Warn in the confirm. */
+  clipboardHoldsInstallPrompt?: boolean;
+  /** --yes (CI): show the guide, skip the interactive copy offer. */
+  yes: boolean;
+  onEvent: (event: string, properties?: Record<string, unknown>) => void;
+}
+
+export async function showDemoGuide(ctx: DemoGuideContext): Promise<void> {
+  const lead = ctx.installPending
+    ? `Installation complete? Let's make sure everything works.`
+    : `Installation complete — let's make sure everything works.`;
+  // clack renders note bodies dimmed; pc.reset per line undoes that (the same
+  // escape clack itself uses for note titles) so everything reads at full
+  // strength. The prompt is set apart by color — brand purple is the agent's
+  // text, plain is the human's steps. Only the closing aside stays dim, and
+  // re-dims inside the reset.
+  p.note(
+    [
+      lead,
+      pc.bold('Follow these steps:'),
+      '',
+      '1. Start (or restart) your local dev server so the new snippet is live.',
+      '2. Open the app in your browser and click around for a minute —',
+      '   Subtext is capturing your session as you go.',
+      `3. Open ${ctx.agentName} at this project and paste in the demo prompt`,
+      '   below — that part is the agent\'s job:',
+      '',
+      ...DEMO_PROMPT_LINES.map((line) => `   ${brandPurple(line)}`),
+      '',
+      pc.dim('Captured sessions can take a minute or two to show up.'),
+    ]
+      .map((line) => pc.reset(line))
+      .join('\n'),
+    'First run',
+  );
+  ctx.onEvent('demo_guide_shown', { install_pending: ctx.installPending });
+
+  if (ctx.yes) return;
+
+  const answer = await p.confirm({
+    message: ctx.clipboardHoldsInstallPrompt
+      ? `Copy the demo prompt to your clipboard? ${pc.dim(
+          '(replaces the install prompt currently on it)',
+        )}`
+      : 'Copy the demo prompt to your clipboard?',
+  });
+  if (p.isCancel(answer) || !answer) return;
+
+  try {
+    await clipboard.write(DEMO_PROMPT);
+  } catch {
+    p.log.warn('Could not write to the clipboard — copy the prompt from the note above.');
+    return;
+  }
+  ctx.onEvent('demo_prompt_copied');
+  p.log.success(`Demo prompt copied — paste it into ${ctx.agentName} after you've clicked around.`);
+}

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -28,11 +28,14 @@ export interface DemoGuideContext {
   /** Harness display name ("Claude Code"), or "your coding agent" when the
    * user took the raw prompt and we never learned which one. */
   agentName: string;
-  /** True when the install prompt still has to run (manual copy / GUI
-   * handoff) — the guide then leads with "once the install finishes". */
+  /** True when the install isn't confirmed done — the prompt still has to run
+   * (manual copy / GUI handoff), or a terminal run ended without the agent's
+   * install-success marker. The guide then leads with "once the install
+   * finishes" instead of presenting the snippet as already live. */
   installPending: boolean;
-  /** Manual path only: the install prompt currently occupies the clipboard,
-   * so copying the demo prompt now would clobber it. Warn in the confirm. */
+  /** Manual and GUI handoff paths: the install prompt currently occupies the
+   * clipboard, so copying the demo prompt now would clobber it. Warn in the
+   * confirm. */
   clipboardHoldsInstallPrompt?: boolean;
   /** --yes (CI): show the guide, skip the interactive copy offer. */
   yes: boolean;
@@ -41,7 +44,7 @@ export interface DemoGuideContext {
 
 export async function showDemoGuide(ctx: DemoGuideContext): Promise<void> {
   const lead = ctx.installPending
-    ? `Installation complete? Let's make sure everything works.`
+    ? `Once the install finishes, make sure everything works.`
     : `Installation complete — let's make sure everything works.`;
   // clack renders note bodies dimmed; pc.reset per line undoes that (the same
   // escape clack itself uses for note titles) so everything reads at full

--- a/src/logo.ts
+++ b/src/logo.ts
@@ -78,6 +78,19 @@ function fg(rgb: Rgb): string {
 
 const RESET = '\x1b[0m';
 
+/**
+ * The logo's base purple, for inline text elsewhere in the wizard. 256-color
+ * terminals get xterm 99 (the logo's own resting fallback); no-color output
+ * passes through untouched. Closes with default-foreground, not a full reset,
+ * so it composes inside other styling.
+ */
+export function brandPurple(text: string): string {
+  const mode = colorMode();
+  if (mode === 'none') return text;
+  const open = mode === '256' ? '\x1b[38;5;99m' : fg(BASE_PURPLE);
+  return `${open}${text}\x1b[39m`;
+}
+
 /** Base color for a row — a subtle deep-to-bright vertical gradient. */
 function rowColor(y: number, rows: number): Rgb {
   return lerp(DEEP_PURPLE, BASE_PURPLE, y / Math.max(1, rows - 1));

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,6 +5,7 @@ import { authenticate } from './auth.js';
 import { chooseAgent, detectAgents, MANUAL_CHOICE } from './agents/index.js';
 import type { WizardOptions } from './config.js';
 import { WIZARD_VERSION, telemetryUrl } from './config.js';
+import { showDemoGuide } from './demo.js';
 import { CancelledError, selectIntegrations } from './integrations.js';
 import { showLogo } from './logo.js';
 import { guidePluginSetup } from './plugin.js';
@@ -174,6 +175,13 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       await offerPluginSetup(MANUAL_CHOICE, auth.region, options, (event, properties) =>
         telemetry.note(event, properties),
       );
+      await showDemoGuide({
+        agentName: 'your coding agent',
+        installPending: true,
+        clipboardHoldsInstallPrompt: copied,
+        yes: options.yes,
+        onEvent: (event, properties) => telemetry.note(event, properties),
+      });
       p.outro('Run this installer again any time with: npx @subtextdev/subtext-wizard');
       await telemetry.flush();
       return 0;
@@ -250,6 +258,12 @@ export async function runWizard(options: WizardOptions): Promise<number> {
 
     if (result.mode === 'handoff') {
       p.note(result.followUp?.join('\n') ?? '', 'Next steps');
+      await showDemoGuide({
+        agentName: chosen.definition.name,
+        installPending: true,
+        yes: options.yes,
+        onEvent: (event, properties) => telemetry.note(event, properties),
+      });
       p.outro('Finish the install in your agent — it will guide you from here.');
     } else if (result.exitCode === 0) {
       // Terminal install succeeded — wire Subtext into the harness that ran it
@@ -257,8 +271,14 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       await offerPluginSetup(chosen, auth.region, options, (event, properties) =>
         telemetry.note(event, properties),
       );
+      await showDemoGuide({
+        agentName: chosen.definition.name,
+        installPending: false,
+        yes: options.yes,
+        onEvent: (event, properties) => telemetry.note(event, properties),
+      });
       p.outro(
-        'Subtext install finished. Review the changes (and subtext-setup-report.md), then deploy to start capturing sessions.',
+        'Subtext install finished. Review the changes (and subtext-setup-report.md), then deploy to capture real user sessions.',
       );
     } else {
       p.outro(

--- a/src/run.ts
+++ b/src/run.ts
@@ -246,13 +246,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
     // install-step marker; exit 0 without it is recorded as `partial`. (When
     // the prompt carried no marker instructions, exit code is all we have.)
     // GUI handoffs log their own `complete` via the plugin's MCP tool.
+    const installConfirmed = agentInstallSucceeded || promptTelemetry !== 'stdout';
     if (result.mode === 'ran') {
-      const outcome =
-        result.exitCode !== 0
-          ? 'fail'
-          : agentInstallSucceeded || promptTelemetry !== 'stdout'
-            ? 'success'
-            : 'partial';
+      const outcome = result.exitCode !== 0 ? 'fail' : installConfirmed ? 'success' : 'partial';
       telemetry.step('complete', outcome, { harness: chosen.definition.id });
     }
 
@@ -261,19 +257,22 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       await showDemoGuide({
         agentName: chosen.definition.name,
         installPending: true,
+        clipboardHoldsInstallPrompt: result.clipboardHoldsPrompt,
         yes: options.yes,
         onEvent: (event, properties) => telemetry.note(event, properties),
       });
       p.outro('Finish the install in your agent — it will guide you from here.');
     } else if (result.exitCode === 0) {
-      // Terminal install succeeded — wire Subtext into the harness that ran it
+      // Terminal run finished — wire Subtext into the harness that ran it
       // (packaged plugin where one exists, raw MCP entry otherwise).
       await offerPluginSetup(chosen, auth.region, options, (event, properties) =>
         telemetry.note(event, properties),
       );
       await showDemoGuide({
         agentName: chosen.definition.name,
-        installPending: false,
+        // Exit 0 without the agent's install marker means the install may have
+        // been refused or abandoned — frame the guide as post-install work.
+        installPending: !installConfirmed,
         yes: options.yes,
         onEvent: (event, properties) => telemetry.note(event, properties),
       });


### PR DESCRIPTION
- this pr adds a first run step at the end of the flow so that users can engage with subtext post install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI onboarding and UX only; no auth, capture, or install logic changes beyond an extra non-throwing closing step and telemetry notes.
> 
> **Overview**
> Adds a **First run** closing step so users can validate capture right after setup: restart dev, click around locally, then paste a demo prompt into their agent to review the latest session via Subtext tools.
> 
> New `showDemoGuide` drives the note, optional clipboard copy (skipped under `--yes`), and telemetry (`demo_guide_shown`, `demo_prompt_copied`). Copying warns when the install prompt still occupies the clipboard—GUI handoffs now return `clipboardHoldsPrompt` on `LaunchResult` for that path. Wording adapts when install is still pending (manual/GUI handoff or terminal exit 0 without an install-success marker). `brandPurple` highlights the agent prompt in the note; the success outro now mentions deploying to capture real sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d40398ea9c8b6804bcbab2d728ded73b3ca5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->