### PR TITLE
Re-enable npm provenance (merge after repo is public)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm run build
 
       - name: Publish npm package
-        # NO --provenance: npm rejects provenance attestations from private
-        # source repos (E422 "Unsupported ... visibility: private"). This repo
-        # is private, so provenance was intentionally dropped in 059d114.
-        run: npm publish --access public
+        # --provenance is automatic under trusted publishing, but explicit is
+        # self-documenting. Only valid once the source repo is PUBLIC — npm
+        # rejects provenance from private repos (E422).
+        run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "https://github.com/fullstorydev/subtext-wizard.git"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "subtext",


### PR DESCRIPTION
## What

Re-enables npm provenance publishing, which is currently disabled:
- adds `--provenance` back to the `Release` workflow's publish step
- adds `"provenance": true` back to `publishConfig` in `package.json`

## ⚠️ DO NOT MERGE YET

Merge this **only after `fullstorydev/subtext-wizard` is made public.**

npm rejects provenance attestations from private source repos:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Unsupported GitHub Actions source repository visibility: "private".
Only public source repositories are supported when publishing with provenance.
```

Provenance was originally dropped in 059d114 for exactly this reason. It got
accidentally re-added during the security-review pass (7d50bed), which broke
the 0.1.6 publish (E422). The fix (`36a5b2e`) removed it again. This PR is the
deferred re-enable for when the repo goes public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only config; risk is operational (failed publish if merged while the repo is still private), not runtime or security logic changes.
> 
> **Overview**
> **Re-enables npm provenance** on publish so releases can ship Sigstore attestations once the GitHub source repo is public.
> 
> The **Release** workflow publish step now runs `npm publish --access public --provenance` (with comments noting E422 if the repo is still private). **`package.json`** adds `"provenance": true` under `publishConfig` alongside existing public access.
> 
> **Do not merge until the repository is public** — the same visibility check that blocked 0.1.6 will fail CI/release publishes from a private repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c64e97e4ba5db40cef732be79ad5cf33e0754d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->