### PR TITLE
ux enhancements

### DIFF
--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { firstExistingPath, runTerminalAgent, sanitizeTerminalOutput, which } from './helpers.js';
+import { printAgentAction, printAgentText } from './output.js';
 import { extractTelemetryMarkers } from './telemetry-marker.js';
 import type { AgentDefinition, LaunchContext, LaunchResult } from './types.js';
 
@@ -59,6 +60,7 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
   p.log.info(pc.dim('Claude Code is doing the install in this terminal. Progress below.'));
 
   let resultText: string | undefined;
+  let lastAssistantText: string | undefined;
   const exitCode = await runTerminalAgent({
     binaryPath: ctx.binaryPath!,
     args: [
@@ -91,9 +93,12 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
             const text = sanitizeTerminalOutput(
               extractTelemetryMarkers(block.text, ctx.onTelemetry),
             ).trim();
-            if (text) console.log(pc.dim(text));
+            if (text) {
+              printAgentText(text);
+              lastAssistantText = text;
+            }
           } else if (block.type === 'tool_use') {
-            console.log(pc.dim(`  → ${describeToolUse(block.name, block.input)}`));
+            printAgentAction(describeToolUse(block.name, block.input));
             ctx.onEvent?.('agent_tool_use', { tool: block.name });
           }
         }
@@ -104,13 +109,16 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
   });
 
   if (resultText) {
-    // The result event duplicates the final assistant message, so any marker
-    // lines already stripped from the streamed display would resurface here.
-    // Strip them again; re-reported markers are deduped by the caller.
+    // The result event normally duplicates the final assistant message, so any
+    // marker lines already stripped from the streamed display would resurface
+    // here. Strip them again (re-reported markers are deduped by the caller),
+    // and only show the note when the result differs from what was already
+    // streamed — e.g. error-subtype results that never appeared as an
+    // assistant message. Otherwise the same summary would print twice.
     const cleaned = sanitizeTerminalOutput(
       extractTelemetryMarkers(resultText, ctx.onTelemetry),
     ).trim();
-    if (cleaned) p.note(cleaned, 'Claude Code result');
+    if (cleaned && cleaned !== lastAssistantText) p.note(cleaned, 'Claude Code result');
   }
   return { mode: 'ran', exitCode };
 }

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -11,7 +11,8 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
   // `codex exec` is Codex's non-interactive mode; --full-auto lets it edit
   // files and run commands inside its workspace sandbox without prompting.
   // We pipe stdout (rather than inherit) so the wizard can pull telemetry
-  // markers out of the stream; every other line is echoed through unchanged.
+  // markers out of the stream; every other line is echoed through with the
+  // shared agent-output styling (purple gutter bar).
   const exitCode = await runTerminalAgent({
     binaryPath: ctx.binaryPath!,
     args: ['exec', '--full-auto', ctx.prompt],

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -13,7 +13,8 @@ async function launch(ctx: LaunchContext): Promise<LaunchResult> {
   // repo/doc content ("run this command") can't reach a shell. (--yolo would
   // auto-approve everything, including command execution.) We pipe stdout
   // (rather than inherit) so the wizard can pull telemetry markers out of the
-  // stream; every other line is echoed through unchanged.
+  // stream; every other line is echoed through with the shared agent-output
+  // styling (purple gutter bar).
   const exitCode = await runTerminalAgent({
     binaryPath: ctx.binaryPath!,
     args: ['--approval-mode', 'auto_edit', '-p', ctx.prompt],

--- a/src/agents/output.ts
+++ b/src/agents/output.ts
@@ -1,0 +1,31 @@
+import pc from 'picocolors';
+import { brandPurple, purpleShade } from '../logo.js';
+
+/**
+ * Shared styling for a terminal agent's streamed output: every line the agent
+ * prints gets a purple gutter bar, so the whole run reads as one visually
+ * fenced block — clearly the agent talking, not the wizard. The bar's shade
+ * drifts along the logo's purple ramp line by line, a slow shimmer flowing
+ * down the margin that echoes the startup animation. Degradation (256-color,
+ * no-color) is handled by purpleShade.
+ */
+
+let gutterLine = 0;
+
+function gutter(): string {
+  // Ping-pong along the ramp — one full deep→glow→deep sweep every ~24 lines.
+  const t = (Math.sin((gutterLine++ * Math.PI) / 12) + 1) / 2;
+  return purpleShade('┃', t);
+}
+
+/** Print a block of agent text (may span multiple lines), gutter-barred and dimmed. */
+export function printAgentText(text: string): void {
+  for (const line of text.split('\n')) {
+    console.log(`${gutter()} ${pc.dim(line)}`);
+  }
+}
+
+/** Print an agent action (tool use) — same gutter, purple arrow so actions pop. */
+export function printAgentAction(text: string): void {
+  console.log(`${gutter()} ${brandPurple('→')} ${pc.dim(text)}`);
+}

--- a/src/agents/telemetry-marker.ts
+++ b/src/agents/telemetry-marker.ts
@@ -1,4 +1,5 @@
 import { sanitizeTerminalOutput } from './helpers.js';
+import { printAgentText } from './output.js';
 import type { WorkflowEventMetadata, WorkflowOutcome, WorkflowStep } from '../telemetry.js';
 
 /**
@@ -121,8 +122,9 @@ export function parseTelemetryMarker(line: string): StepMarker | null {
 
 /**
  * onStdoutLine handler for terminal agents whose raw output is piped through
- * the wizard (codex, gemini): consume marker lines, echo everything else to
- * the user's terminal unchanged.
+ * the wizard (codex, gemini): consume marker lines, echo everything else
+ * through the shared agent-output styling (purple gutter bar) so all
+ * terminal agents' streams look the same.
  */
 export function makeMarkerLineFilter(
   onMarker?: (marker: StepMarker) => void,
@@ -130,7 +132,7 @@ export function makeMarkerLineFilter(
   return (line) => {
     const marker = parseTelemetryMarker(line);
     if (marker) onMarker?.(marker);
-    else process.stdout.write(`${sanitizeTerminalOutput(line)}\n`);
+    else printAgentText(sanitizeTerminalOutput(line));
   };
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,7 +42,10 @@ export interface SubtextAuth {
  * The access token is `<realm>.oauth!<JWT>`; the JWT payload carries
  * `org_id` and `sub` (user email), so no extra "who am I" call is needed.
  */
-export async function authenticate(options: WizardOptions): Promise<SubtextAuth> {
+export async function authenticate(
+  options: WizardOptions,
+  openBrowser = true,
+): Promise<SubtextAuth> {
   if (options.apiKey) {
     p.log.info('Using the token you provided — skipping browser login.');
     const claims = decodeTokenClaims(options.apiKey);
@@ -100,12 +103,17 @@ export async function authenticate(options: WizardOptions): Promise<SubtextAuth>
   if (OAUTH_SCOPES) authorizeUrl.searchParams.set('scope', OAUTH_SCOPES);
 
   p.log.step('Log in to Subtext to link this install to your org.');
-  p.log.info(`If your browser doesn't open, visit:\n${pc.cyan(authorizeUrl.toString())}`);
 
-  try {
-    await open(authorizeUrl.toString());
-  } catch {
-    // URL is printed above; the user can open it manually.
+  if (openBrowser) {
+    p.log.info(`If your browser doesn't open, visit:\n${pc.cyan(authorizeUrl.toString())}`);
+    try {
+      await open(authorizeUrl.toString());
+    } catch {
+      // URL is printed above; the user can open it manually.
+    }
+  } else {
+    // User declined the browser popup — just hand them the link to open.
+    p.log.info(`Open this link in your browser to log in:\n${pc.cyan(authorizeUrl.toString())}`);
   }
 
   const spinner = p.spinner();

--- a/src/logo.ts
+++ b/src/logo.ts
@@ -91,6 +91,29 @@ export function brandPurple(text: string): string {
   return `${open}${text}\x1b[39m`;
 }
 
+/**
+ * A shade along the logo's purple ramp: t=0 is deep purple, t=0.5 the base,
+ * t=1 the glow. Used for the agent-output gutter, whose shade drifts along
+ * the ramp as lines stream — a slow shimmer echoing the logo animation.
+ * 256-color terminals bucket onto the logo's own fallback codes; no-color
+ * output passes through untouched. Closes with default-foreground, not a
+ * full reset, so it composes inside other styling.
+ */
+export function purpleShade(text: string, t: number): string {
+  const mode = colorMode();
+  if (mode === 'none') return text;
+  const clamped = Math.max(0, Math.min(1, t));
+  if (mode === '256') {
+    const code = clamped < 0.25 ? 61 : clamped < 0.5 ? 99 : clamped < 0.75 ? 141 : 189;
+    return `\x1b[38;5;${code}m${text}\x1b[39m`;
+  }
+  const rgb =
+    clamped < 0.5
+      ? lerp(DEEP_PURPLE, BASE_PURPLE, clamped * 2)
+      : lerp(BASE_PURPLE, GLOW, clamped * 2 - 1);
+  return `${fg(rgb)}${text}\x1b[39m`;
+}
+
 /** Base color for a row — a subtle deep-to-bright vertical gradient. */
 function rowColor(y: number, rows: number): Rgb {
   return lerp(DEEP_PURPLE, BASE_PURPLE, y / Math.max(1, rows - 1));

--- a/src/promptReview.ts
+++ b/src/promptReview.ts
@@ -21,18 +21,29 @@ export interface PromptReviewChoices {
   proceedLabel: string;
   /** Optional hint shown next to the proceed option (e.g. "edits files in /app, auto-accepting"). */
   proceedHint?: string;
+  /** Honor the run-wide browser preference: when false, we serve the prompt
+   * page but print the link instead of popping a browser tab. */
+  openInBrowser?: boolean;
 }
 
 export async function offerPromptReview(
   prompt: string,
-  { proceedLabel, proceedHint }: PromptReviewChoices,
+  { proceedLabel, proceedHint, openInBrowser = true }: PromptReviewChoices,
 ): Promise<{ reviewed: boolean }> {
   const lineCount = prompt.split('\n').length;
   const choice = await p.select({
     message: `The install prompt is ready (${lineCount} lines) — it tells your coding agent exactly what to do.`,
     options: [
-      { value: 'proceed', label: proceedLabel, hint: proceedHint },
-      { value: 'review', label: 'Review the prompt first', hint: 'opens in your browser' },
+      {
+        value: 'proceed',
+        label: proceedLabel,
+        hint: proceedHint,
+      },
+      {
+        value: 'review',
+        label: 'Review the prompt first',
+        hint: openInBrowser ? 'opens in your browser' : 'served locally — I print the link',
+      },
       { value: 'cancel', label: 'Cancel' },
     ],
   });
@@ -47,11 +58,20 @@ export async function offerPromptReview(
   try {
     const served = await servePromptPage(renderPromptHtml(prompt));
     closeServer = served.close;
-    p.log.info(`Prompt opened at ${pc.cyan(served.url)} — the page stays up until you answer below.`);
-    try {
-      await open(served.url);
-    } catch {
-      // URL is printed above; the user can open it manually.
+    if (openInBrowser) {
+      p.log.info(
+        `Prompt opened at ${pc.cyan(served.url)} — the page stays up until you answer below.`,
+      );
+      try {
+        await open(served.url);
+      } catch {
+        // URL is printed above; the user can open it manually.
+      }
+    } else {
+      // User opted out of browser popups — hand them the link instead.
+      p.log.info(
+        `Open the prompt at ${pc.cyan(served.url)} — the page stays up until you answer below.`,
+      );
     }
   } catch {
     // No server? Fall back to a temp file the user can open themselves —

--- a/src/run.ts
+++ b/src/run.ts
@@ -34,7 +34,25 @@ export async function runWizard(options: WizardOptions): Promise<number> {
 
   try {
     // 1. Login (browser flow) so we can fetch the org-specific snippet.
-    const auth = await authenticate(options);
+    //    Ask once, up front, before hijacking the browser — a tab popping open
+    //    unprompted is jarring. The answer governs every automatic page-open in
+    //    the run (login here, prompt review later); on "no" we just print the
+    //    links instead. Skipped with --api-key, where there's no browser login.
+    p.log.info(`Wizard running in: ${pc.cyan(options.dir)}`);
+    let openInBrowser = true;
+    if (!options.apiKey) {
+      const consent = await p.confirm({
+        message: 'Launch browser automatically to log in?',
+      });
+      if (p.isCancel(consent)) throw new CancelledError();
+      openInBrowser = consent;
+    }
+    const auth = await authenticate(options, openInBrowser);
+    telemetry.note('auth_completed', { via: options.apiKey ? 'api_key' : 'browser' });
+
+    // 2. Org-specific capture snippet.
+    const snippet = await fetchCaptureSnippet(auth, options);
+    telemetry.note('snippet_fetched');
 
     // Consent gate: nothing is collected unless the user says yes here.
     // --no-telemetry skips the question (already opted out).
@@ -49,16 +67,12 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       if (!consent) telemetry.disable();
     }
     // The telemetry endpoint needs an authenticated session, so delivery can
-    // only start now — anything that fails before login goes unreported
-    // (flagged for review). Mock runs never send real events.
+    // only start now — no step events are sent before this point, so nothing
+    // is lost by asking after the snippet fetch. Mock runs never send real
+    // events.
     if (telemetryEnabled && !options.mock) {
       telemetry.authorize(telemetryUrl(auth.region), auth.accessToken);
     }
-    telemetry.note('auth_completed', { via: options.apiKey ? 'api_key' : 'browser' });
-
-    // 2. Org-specific capture snippet.
-    const snippet = await fetchCaptureSnippet(auth, options);
-    telemetry.note('snippet_fetched');
 
     // 3. Which integrations should the agent look for? The selection only
     //    steers the prompt — analytics_providers telemetry is left to what
@@ -147,6 +161,7 @@ export async function runWizard(options: WizardOptions): Promise<number> {
         proceedLabel,
         proceedHint:
           chosen !== MANUAL_CHOICE && isTerminalRun ? `will run in ${options.dir}` : undefined,
+        openInBrowser,
       });
       if (reviewed) telemetry.note('prompt_reviewed');
     }


### PR DESCRIPTION
Ask before opening the browser, reorder setup steps, and style agent output

Browser consent (new questionnaire)

Running the installer used to pop the login page open in the user's browser unannounced, which is jarring. Now, right after the logo shimmer/intro, the wizard prints where it's running and asks first:

●  Wizard running in: /path/to/project
◆  Launch browser automatically to log in?

- The answer governs every automatic page-open in the run: the OAuth login page (auth.ts) and the pre-handoff prompt-review page (promptReview.ts).
- On No, nothing auto-opens — the wizard prints each link for the user to open themselves. The OAuth loopback flow works identically either way.
- Defaults to Yes (enter keeps the old behavior); skipped entirely with --api-key, which never does a browser login.
- The coding-agent app handoff (Cursor/VS Code/etc.) is deliberately not gated — that launch is the action the user explicitly selected.

Step reordering

The capture-snippet fetch now happens before the telemetry-consent question (login → snippet → consent → integrations). Safe because no step() events are deliverable before telemetry.authorize(), which still runs before the first start event — only debug-only note() calls happen in between.

Styled agent output stream

Terminal-agent output (Claude Code, Codex, Gemini) is now visually fenced with a purple gutter bar whose shade drifts along the logo's deep-purple → glow ramp as lines stream — a slow shimmer down the margin echoing the startup animation. Tool actions get a bright purple →:

┃ I'll start by running the Step 1 pre-check on this codebase.
┃ → Read: package.json
┃ → Bash: npm install @fullstory/browser

- New purpleShade() in logo.ts (reuses the logo palette; degrades to xterm 256 buckets, passes through untouched with no color).
- New shared src/agents/output.ts printers, used by Claude Code's stream-json handler and by makeMarkerLineFilter (Codex/Gemini), so all three agents' streams look identical.
- Sanitization and telemetry-marker extraction are unchanged.

Deduplicated Claude Code result box

Claude Code's stream-json result event duplicates the final assistant message, so the summary printed twice (once in the styled stream, again in a Claude Code result note). The launcher now remembers the last streamed assistant text and skips the note when the result matches it — the box only appears when the result carries something that never streamed (e.g. error-subtype results).

Testing

- tsc typecheck/build passes.
- Verified gutter gradient output (truecolor escape codes step smoothly along the ramp; piped/no-color output degrades to plain text).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and display-only changes; OAuth and telemetry behavior are unchanged aside from consent gating and step ordering that preserves existing delivery guarantees.
> 
> **Overview**
> The wizard now **asks before opening the browser** (skipped with `--api-key`): it prints the working directory, confirms whether to launch login automatically, and reuses that choice for OAuth and optional prompt-review pages—on decline, links are printed instead of auto-opening tabs.
> 
> **Setup order** moves org snippet fetch **before** the telemetry consent question; delivery still only starts after `telemetry.authorize()`, so no step events are lost.
> 
> **Terminal agent output** (Claude Code, Codex, Gemini) is routed through new shared printers with a **purple gutter bar** whose shade animates via `purpleShade()` in `logo.ts`. Claude Code also **skips duplicate** `Claude Code result` notes when the final result matches the last streamed assistant text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17280bc13e4c74b91cd1ad31dd6f337def4c13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->