### PR TITLE
Removing references to various internal services in docs

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -28,8 +28,8 @@ export interface SubtextAuth {
 }
 
 /**
- * Authenticate against Fullstory's production OAuth 2.1 server (heimdall,
- * auth.fullstory.com) using the standard native-app flow:
+ * Authenticate against Fullstory's production OAuth 2.1 server
+ * (auth.fullstory.com) using the standard native-app flow:
  *
  *   1. Dynamically register a public client (RFC 7591) unless a
  *      pre-registered client id is configured.
@@ -315,7 +315,7 @@ async function exchangeCode(
       client_id: args.clientId,
       code_verifier: args.verifier,
       // RFC 8707: the token request repeats the resource indicator from the
-      // authorization request. Heimdall ignores it today (no audience
+      // authorization request. The OAuth server ignores it today (no audience
       // restriction yet) but MCP-spec clients send it on both requests.
       resource: args.resource,
     }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,8 @@
  * Central configuration.
  *
  * Auth and snippet endpoints are REAL production Fullstory endpoints
- * (verified against the mn monorepo: heimdall OAuth service and the public
- * snippet service). Anything still marked PLACEHOLDER has no backend yet.
+ * (the production OAuth service and the public snippet service). Anything
+ * still marked PLACEHOLDER has no backend yet.
  */
 
 import fs from 'node:fs';
@@ -78,7 +78,7 @@ export function warnOnDevOverrides(): void {
   }
 }
 
-/** OAuth 2.1 authorization server (heimdall). Discovery metadata lives at
+/** OAuth 2.1 authorization server. Discovery metadata lives at
  * `/.well-known/oauth-authorization-server`. */
 export function authBaseUrl(region: Region): string {
   return (
@@ -116,12 +116,12 @@ export const OAUTH_REGISTER_PATH = '/oauth/register';
 
 /**
  * Pre-registered Subtext OAuth client ids, per realm. Populate once the
- * Subtext client is registered in each realm's heimdall — a stable
+ * Subtext client is registered with each realm's OAuth server — a stable
  * first-party client avoids polluting the client table and hitting the
  * registration rate limit with a fresh RFC 7591 registration on every run.
  * Until then the wizard falls back to dynamic registration. (Branding does
- * not depend on this: heimdall keys the Subtext-branded OAuth pages off the
- * RFC 8707 resource indicator — see subtextOauthResource below.)
+ * not depend on this: the OAuth server keys the Subtext-branded OAuth pages
+ * off the RFC 8707 resource indicator — see subtextOauthResource below.)
  */
 const PREREGISTERED_OAUTH_CLIENT_IDS: Partial<Record<Region, string>> = {
   // us: pending pre-registration
@@ -147,12 +147,12 @@ export const OAUTH_SCOPES = process.env.SUBTEXT_OAUTH_SCOPES ?? 'sessions:read';
 
 /**
  * RFC 8707 resource indicator sent on the authorization and token requests,
- * identifying the Subtext MCP resource. Heimdall keys the Subtext branding
- * of its OAuth pages off this value's /mcp/subtext path when it is the sole
- * resource named (isSubtextResource): the consent page in cowpaths/mn#106970
- * and the login page the wizard's browser flow hits first in cowpaths/mn#106971.
+ * identifying the Subtext MCP resource. The OAuth server keys the Subtext
+ * branding of its OAuth pages off this value's /mcp/subtext path when it is
+ * the sole resource named (isSubtextResource): the consent page and the login
+ * page the wizard's browser flow hits first.
  * MCP clients send the same indicator, so the wizard's login gets the same
- * branded flow they do. The string must match gangplank's advertised RFC 9728
+ * branded flow they do. The string must match the API's advertised RFC 9728
  * metadata (https://api.<Domain>/mcp/subtext) byte-for-byte.
  */
 export function subtextOauthResource(region: Region): string {
@@ -164,9 +164,9 @@ export function subtextOauthResource(region: Region): string {
 export const SNIPPET_PATH = '/code/v2/snippet';
 
 /**
- * Telemetry ingestion endpoint (lidar, fronted by gangplank). Accepts a
- * protojson `WorkflowEvent` and requires an authenticated session — we send
- * the user's OAuth access token as `Authorization: Bearer`.
+ * Telemetry ingestion endpoint. Accepts a protojson `WorkflowEvent` and
+ * requires an authenticated session — we send the user's OAuth access token
+ * as `Authorization: Bearer`.
  */
 const TELEMETRY_PATH = '/subtext/telemetry';
 

--- a/src/prompt/build.ts
+++ b/src/prompt/build.ts
@@ -54,7 +54,7 @@ const COMPLETE_ROW = `| Step 8 | \`complete\` | \`total_duration_ms\` (int), \`t
 /**
  * GUI-handoff variant: the agent logs milestones through the Subtext
  * plugin's `telemetry-event` MCP tool. Adapted from the settings-ui setup
- * prompt (mn#107606), minus the consent ask — the wizard already asked in
+ * prompt, minus the consent ask — the wizard already asked in
  * the CLI, and this section only renders when the user said yes.
  */
 function mcpTelemetrySection(): string {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,8 +1,8 @@
 import { WIZARD_VERSION } from './config.js';
 
 /**
- * Fire-and-forget telemetry against the real `/subtext/telemetry` endpoint
- * (lidar). The endpoint accepts a protojson `WorkflowEvent` (lidar.proto) and
+ * Fire-and-forget telemetry against the real `/subtext/telemetry` endpoint.
+ * The endpoint accepts a protojson `WorkflowEvent` and
  * requires an authenticated session, so nothing can be delivered until the
  * user has logged in — call authorize() with the OAuth access token first.
  * Events are POSTed in the background as they happen; nothing ever blocks the
@@ -16,7 +16,7 @@ import { WIZARD_VERSION } from './config.js';
  * - Events fired before login (e.g. auth failures) cannot be delivered at all.
  */
 
-/** Steps accepted by the endpoint — the lidar WorkflowStep enum. Anything
+/** Steps accepted by the endpoint — the WorkflowStep enum. Anything
  * else is rejected with 400, so granular CLI milestones that don't map to a
  * step go through note() (debug-only) instead. */
 export type WorkflowStep =
@@ -30,10 +30,10 @@ export type WorkflowStep =
   | 'mask_pii'
   | 'complete';
 
-/** The lidar Outcome enum; empty string means "in progress". */
+/** The Outcome enum; empty string means "in progress". */
 export type WorkflowOutcome = 'success' | 'partial' | 'fail' | 'skipped';
 
-/** protojson form of lidar's WorkflowEventMetadata. Field names mirror the
+/** protojson form of the WorkflowEventMetadata. Field names mirror the
  * proto exactly (snake_case) so wizard-sent events and the MCP telemetry-event
  * tool all speak one convention. Fields are sparse — only those relevant to a
  * given step are set. */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only edits with no behavioral or security impact.
> 
> **Overview**
> **Documentation-only cleanup** across `auth.ts`, `config.ts`, `prompt/build.ts`, and `telemetry.ts` so in-repo comments match what external readers would expect.
> 
> Internal names (**heimdall**, **lidar**, **gangplank**) and monorepo references (**mn**, **cowpaths/mn#…**) are replaced with neutral wording like “OAuth server,” “telemetry endpoint,” and “the API.” OAuth behavior descriptions (RFC 8707 resource indicator, Subtext branding, pre-registered clients) are unchanged in meaning—only the labels and cross-repo pointers are removed.
> 
> No runtime logic, config values, or API contracts were modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495f71e8430d91279bf158232c010d57d79b921a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->