### PR TITLE
Replace old image with new graphic in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Subtext setup wizard
 
-<img width="2560" height="640" alt="Frame 2" src="https://github.com/user-attachments/assets/051400e4-5543-42e4-8114-9c335ca86ded" />
+<img width="2560" height="658" alt="LOCKUP - HORZ - BY FS - LIGHT - COLOR (3)" src="https://github.com/user-attachments/assets/3f0da600-52c8-4fa1-a203-1918e6a6cfda" />
 
 
 ![NPM Downloads](https://img.shields.io/npm/dm/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=240046&color=7b2cbf)


### PR DESCRIPTION
Updated the image in the README to a new graphic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only asset swap with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **top-of-page hero image** in `README.md` to a new horizontal lockup asset.
> 
> The change replaces the previous GitHub-hosted image URL, bumps the displayed height from **640** to **658**, and updates the `alt` text to match the new graphic. No other README content or application code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e1ae19b8c71209803a5d36cbd3aef70e46f657b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->