### PR TITLE
Repaint README shields on the pink ramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <img width="2560" height="658" alt="LOCKUP - HORZ - BY FS - LIGHT - COLOR (3)" src="https://github.com/user-attachments/assets/3f0da600-52c8-4fa1-a203-1918e6a6cfda" />
 
 
-![NPM Downloads](https://img.shields.io/npm/dm/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=240046&color=7b2cbf)
-![NPM Last Updated](https://img.shields.io/npm/last-update/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=3c096c&color=9d4edd)
-![NPM Version](https://img.shields.io/npm/v/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=5a189a&color=e0aaff)
+![NPM Downloads](https://img.shields.io/npm/dm/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=46001f&color=b81b56)
+![NPM Last Updated](https://img.shields.io/npm/last-update/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=6b0f36&color=f5447b)
+![NPM Version](https://img.shields.io/npm/v/%40subtextdev%2Fsubtext-wizard?style=flat-square&labelColor=9a1847&color=ffd6e4)
 
 **Session replay, built for agents.** Subtext is agentic session review: it captures production sessions of your app and connects them to your coding agent — Claude Code, Cursor, Codex, Devin, your own harness — so it can review what real users did, reproduce reported bugs, verify its own UI changes, and manage capture privacy rules, all without leaving the terminal.
 


### PR DESCRIPTION
## Summary
Follow-up to #19: the npm shields in the README still used the old purple palette. Repainted on the pink ramp from the new branding, mirroring the old structure (each badge a step lighter, label darker than value):

| Badge | labelColor | color |
|---|---|---|
| NPM Downloads | `46001f` | `b81b56` (deep pink) |
| NPM Last Updated | `6b0f36` | `f5447b` (brand #F5447B) |
| NPM Version | `9a1847` | `ffd6e4` (pale glow) |

No changeset: README-only, doesn't affect the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README badge URL tweaks with no effect on the published package or application behavior.
> 
> **Overview**
> Updates the three **shields.io** npm badges in `README.md` from the old purple palette to the new pink ramp, keeping the same stepped structure (darker `labelColor`, lighter value `color` per badge).
> 
> **NPM Downloads** → `46001f` / `b81b56`; **NPM Last Updated** → `6b0f36` / `f5447b`; **NPM Version** → `9a1847` / `ffd6e4`. No package or runtime changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0046b5ff1e06a8e62c057ff6e5fc4897556a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->