### PR TITLE
Bump js-yaml to patched 3.15.1 / 4.3.1 (CVE-2026-59870)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@subtextdev/subtext-wizard",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@subtextdev/subtext-wizard",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
@@ -984,9 +984,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

The `npm audit --audit-level=moderate` CI job started failing on a fresh high-severity advisory in `js-yaml` ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution).

Both affected copies are **transitive under the `@changesets/cli` devDependency**, so the published package's runtime deps (clack/clipboardy/open/picocolors) are unaffected — this is purely a dev-tree / CI fix.

`npm audit fix` bumps both within their existing majors:
- `js-yaml` `4.3.0 → 4.3.1` (under `@changesets/parse`)
- `js-yaml` `3.15.0 → 3.15.1` (under `read-yaml-file`)

Lockfile-only change (`npm-shrinkwrap.json`); no source or published-behavior change, so no changeset.

## Testing

`npm audit --audit-level=moderate` → **found 0 vulnerabilities** (the exact CI command). `npm ls js-yaml` confirms both copies are now on the patched versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bumps in the dev tree; published CLI behavior and runtime deps are unaffected.
> 
> **Overview**
> Updates **`npm-shrinkwrap.json`** so CI **`npm audit --audit-level=moderate`** (release workflow) passes again after a high-severity **`js-yaml`** advisory (quadratic CPU use in `!!omap` parsing).
> 
> Both copies are **transitive dev dependencies** under **`@changesets/cli`**: **`js-yaml` 4.3.0 → 4.3.1** (via **`@changesets/parse`**) and **3.15.0 → 3.15.1** (nested under **`read-yaml-file`**). Runtime **`dependencies`** are unchanged; no application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06bd3cf0fd84d72207a2d8701270ccc6fba15512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->