### PR TITLE
Add braille subtext avatar to the startup logo

### DIFF
--- a/.changeset/braille-avatar-logo.md
+++ b/.changeset/braille-avatar-logo.md
@@ -1,0 +1,8 @@
+---
+'@subtextdev/subtext-wizard': patch
+---
+
+The startup logo now shows the subtext avatar — rasterized from the brand-pack
+SVG into a braille dot matrix — beside the SUBTEXT wordmark. The two upper bars
+render white while the down-left accent bar and the wordmark carry the brand
+pink, all under the existing shimmer sweep.

--- a/src/logo.ts
+++ b/src/logo.ts
@@ -1,8 +1,13 @@
 import pc from 'picocolors';
 
 /**
- * The SUBTEXT wordmark in half-block lettering (an homage to classic
- * ANSI/BBS scene fonts), rendered at startup with a pink shimmer sweep.
+ * The subtext avatar — a long central diagonal flanked by two offset bars —
+ * rasterized from the brand-pack SVG into a braille dot matrix (2x4 dots per
+ * cell) and set beside the SUBTEXT wordmark in half-block lettering (an homage
+ * to classic ANSI/BBS scene fonts). The mark stands two rows taller than the
+ * wordmark, which sits vertically centered against it. The two upper bars
+ * render white (per CELL_MASK) while the down-left accent bar and the wordmark
+ * carry the brand pink, all under one shimmer sweep that crosses them together.
  *
  * The animation is cosmetic-only and degrades gracefully: no TTY or no color
  * support prints the art statically; a terminal too small to hold it skips
@@ -11,10 +16,26 @@ import pc from 'picocolors';
 
 // prettier-ignore
 const RAW_ART = [
-  '▄████▄ ██  ██ █████▄ ██████ ██████ ██  ██ ██████',
-  '██▄▄▄▄ ██  ██ ██▄▄█▀   ██   ██▄▄▄▄  ▀██▀    ██',
-  '▀▀▀▀██ ██  ██ ██  ██   ██   ██▀▀▀▀  ▄██▄    ██',
-  '▀████▀ ▀████▀ █████▀   ██   ██████ ██  ██   ██',
+  '⠀⠀⠰⣾⣷⣤⡀⠀',
+  '⣦⣄⠀⠀⠙⠻⠟⠃  ▄████▄ ██  ██ █████▄ ██████ ██████ ██  ██ ██████',
+  '⠻⣿⣿⣶⣤⣀⠀⠀  ██▄▄▄▄ ██  ██ ██▄▄█▀   ██   ██▄▄▄▄  ▀██▀    ██',
+  '⠀⠀⠉⠛⠿⣿⣷⣦  ▀▀▀▀██ ██  ██ ██  ██   ██   ██▀▀▀▀  ▄██▄    ██',
+  '⢠⣴⣶⣤⡀⠈⠙⠻  ▀████▀ ▀████▀ █████▀   ██   ██████ ██  ██   ██',
+  '⠀⠈⠙⠿⡿⠗⠀⠀',
+];
+
+// Per-cell color roles for the mark's braille cells: 'W' white, 'P' pink,
+// '.' none. Aligns with the leading cells of each RAW_ART line; the wordmark
+// (and everything past the mark) is left to the pink shimmer. The two upper
+// bars read white; the down-left accent bar is the brand pink.
+// prettier-ignore
+const CELL_MASK = [
+  '..WWWWW.',
+  'WW..WWWW',
+  'WWWWWW..',
+  '..WWWWWW',
+  'PPPPPWWW',
+  '.PPPPP..',
 ];
 
 type Rgb = readonly [number, number, number];
@@ -22,6 +43,7 @@ type Rgb = readonly [number, number, number];
 const DEEP_PINK: Rgb = [184, 27, 86];
 const BASE_PINK: Rgb = [245, 68, 123]; // #F5447B, the brand accent
 const GLOW: Rgb = [255, 216, 230];
+const WHITE: Rgb = [236, 238, 245]; // cool white for the mark's upper bars
 
 const FRAME_MS = 28;
 const BAND_CORE = 3; // columns of full glow at the shimmer's center
@@ -31,6 +53,17 @@ const BAND_FALLOFF = 8; // columns over which glow fades back to base
 function artLines(): string[] {
   const indent = Math.min(...RAW_ART.map((l) => l.length - l.trimStart().length));
   return RAW_ART.map((l) => `  ${l.slice(indent)}`);
+}
+
+/**
+ * Color-role line for each art line, index-aligned with artLines() so a cell's
+ * role is maskLines()[y][x]. Carries the 2-space indent plus the mark's mask;
+ * every position past the mask (the gap and wordmark) defaults to '.', i.e. the
+ * pink shimmer. 'W' cells render white, so only the down-left accent bar and the
+ * wordmark stay pink.
+ */
+function maskLines(): string[] {
+  return CELL_MASK.map((m) => `  ${m}`);
 }
 
 function colorMode(): 'truecolor' | '256' | 'none' {
@@ -95,21 +128,16 @@ function rowColor(y: number, rows: number): Rgb {
   return lerp(DEEP_PINK, BASE_PINK, y / Math.max(1, rows - 1));
 }
 
-/** Render one frame; bandPos = Infinity renders the resting (no shimmer) state. */
-function renderFrame(lines: string[], bandPos: number, mode: 'truecolor' | '256'): string {
-  if (mode === '256') {
-    // No per-cell gradient at 256 colors — shimmer the whole rows near the band.
-    return lines
-      .map((line, y) => {
-        const d = Math.abs(y * 2 - bandPos);
-        const color = d < BAND_CORE ? '\x1b[38;5;218m' : d < BAND_CORE + BAND_FALLOFF ? '\x1b[38;5;211m' : '\x1b[38;5;204m';
-        return `\x1b[2K${color}${line}${RESET}`;
-      })
-      .join('\n');
-  }
+/**
+ * Render one frame; bandPos = Infinity renders the resting (no shimmer) state.
+ * Coloring is per cell: 'W' cells (the mark's upper bars) are white and pulse to
+ * pure white as the band crosses; every other cell rides the pink ramp.
+ */
+function renderFrame(lines: string[], masks: string[], bandPos: number, mode: 'truecolor' | '256'): string {
   return lines
     .map((line, y) => {
       const base = rowColor(y, lines.length);
+      const mask = masks[y] ?? '';
       let out = '\x1b[2K';
       let current = '';
       for (let x = 0; x < line.length; x++) {
@@ -120,9 +148,32 @@ function renderFrame(lines: string[], bandPos: number, mode: 'truecolor' | '256'
         }
         // Diagonal distance from the shimmer band.
         const d = Math.abs(x + y * 0.6 - bandPos);
-        const color =
-          d < BAND_CORE ? GLOW : d < BAND_CORE + BAND_FALLOFF ? lerp(GLOW, base, (d - BAND_CORE) / BAND_FALLOFF) : base;
-        const code = fg(color);
+        const inCore = d < BAND_CORE;
+        const inFalloff = d < BAND_CORE + BAND_FALLOFF;
+        const white = mask[x] === 'W';
+        let code: string;
+        if (mode === '256') {
+          code = white
+            ? '\x1b[38;5;231m'
+            : inCore
+              ? '\x1b[38;5;218m'
+              : inFalloff
+                ? '\x1b[38;5;211m'
+                : '\x1b[38;5;204m';
+        } else {
+          const color = white
+            ? inCore
+              ? ([255, 255, 255] as Rgb)
+              : inFalloff
+                ? lerp([255, 255, 255], WHITE, (d - BAND_CORE) / BAND_FALLOFF)
+                : WHITE
+            : inCore
+              ? GLOW
+              : inFalloff
+                ? lerp(GLOW, base, (d - BAND_CORE) / BAND_FALLOFF)
+                : base;
+          code = fg(color);
+        }
         if (code !== current) {
           out += code;
           current = code;
@@ -142,6 +193,7 @@ function sleep(ms: number): Promise<void> {
 
 export async function showLogo(): Promise<void> {
   const lines = artLines();
+  const masks = maskLines();
   const width = Math.max(...lines.map((l) => l.length));
   const columns = process.stdout.columns || 80; // 0/undefined = unknown, assume standard
   if (columns < width) {
@@ -157,7 +209,7 @@ export async function showLogo(): Promise<void> {
   const rows = process.stdout.rows ?? 0;
   const canAnimate = process.stdout.isTTY && rows >= lines.length + 2;
   if (!canAnimate) {
-    process.stdout.write(`${renderFrame(lines, Infinity, mode)}\n\n`);
+    process.stdout.write(`${renderFrame(lines, masks, Infinity, mode)}\n\n`);
     return;
   }
 
@@ -167,7 +219,7 @@ export async function showLogo(): Promise<void> {
   try {
     for (let i = 0; i <= frames; i++) {
       const bandPos = -(BAND_CORE + BAND_FALLOFF) + (travel + BAND_CORE + BAND_FALLOFF) * (i / frames);
-      process.stdout.write(renderFrame(lines, i === frames ? Infinity : bandPos, mode));
+      process.stdout.write(renderFrame(lines, masks, i === frames ? Infinity : bandPos, mode));
       process.stdout.write(i === frames ? '\n\n' : `\x1b[${lines.length - 1}A\r`);
       if (i !== frames) await sleep(FRAME_MS);
     }


### PR DESCRIPTION
## Summary
Updates the startup logo ASCII art to include the **subtext avatar** rendered in a braille dot matrix (2×4 dots per cell), set beside the existing SUBTEXT wordmark.

- **Faithful mark** — rasterized directly from the brand-pack avatar SVG (`avatar-bare-color-on-light`): a long central diagonal flanked by an up-right bar and a down-left bar. The 6-row mark stands two rows taller than the wordmark, which sits vertically centered against it.
- **Two-tone coloring** — a per-cell `CELL_MASK` renders the top bar and central diagonal **white**, while the down-left accent bar and the SUBTEXT wordmark carry the **brand pink**. Everything still rides the existing single shimmer sweep; white cells pulse to pure white as the band crosses.
- `renderFrame` now colors per cell for both truecolor and 256-color modes; no-color/too-narrow paths degrade gracefully as before.
- 
<img width="457" height="113" alt="Screenshot 2026-08-11 at 2 23 31 PM" src="https://github.com/user-attachments/assets/22f445be-63f3-485f-8da0-e093b050658b" />

