### PR TITLE
Add optional sightmap corpus setup to the install flow

### DIFF
--- a/.changeset/sightmap-setup.md
+++ b/.changeset/sightmap-setup.md
@@ -1,0 +1,5 @@
+---
+"@subtextdev/subtext-wizard": minor
+---
+
+Offer to build a sightmap component corpus after the install. When setup finishes, the wizard can install the `@sightmap/sightmap` CLI and have your coding agent seed a `.sightmap/` corpus from the codebase — so future Subtext session reviews name your UI components instead of showing raw selectors. Optionally deepens coverage against a running dev server. Offered interactively by default; opt in for unattended runs with `--sightmap`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npx @subtextdev/subtext-wizard
 3. **Asks about your stack** — pick the analytics and product tools you use (PostHog, Amplitude, Mixpanel, Sentry, Segment, and more) so setup can link them up.
 4. **Finds your coding agent** — detects Claude Code, Codex, Gemini CLI, Cursor, Windsurf, VS Code, Zed, or Claude Desktop.
 5. **Hands the install to your own agent** — no bundled agent; it drives the one you already use to wire up the capture snippet, MCP server, skills, and commands.
+6. **Offers to build a sightmap** — optionally installs the [`@sightmap/sightmap`](https://docs.sightmap.org/start/quickstart) CLI and has your agent seed a `.sightmap/` component corpus, so later session reviews name your UI ("add-to-cart button") instead of showing raw selectors.
 
 When it finishes, your agent is connected to your sessions. See the [Subtext repo](https://github.com/fullstorydev/subtext) for what it can do from there.
 
@@ -45,6 +46,9 @@ When it finishes, your agent is connected to your sessions. See the [Subtext rep
 --agent <id>            Skip the agent picker (claude-code, codex, gemini, cursor,
                         windsurf, vscode, zed, claude-desktop, manual)
 --integrations <list>   Comma-separated tools to target, skips the picker
+--sightmap              Also build a .sightmap/ component corpus so reviews name
+                        your UI. Offered interactively by default; this flag opts
+                        in for unattended --yes runs.
 --print-prompt          Print the install prompt instead of launching an agent
 --no-telemetry          Opt out of telemetry. Anonymous install telemetry (step
                         progress, outcomes, timings, and agent token usage;

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -28,6 +28,9 @@ Options:
                           datadog, launchdarkly, growthbook, intercom, pendo, appcues,
                           userpilot, sprig, segment — unknown names become "Other")
   --print-prompt          Build and print the install prompt instead of launching
+  --sightmap              Also build a .sightmap/ component corpus so session
+                          reviews name your UI. Offered interactively by default;
+                          this flag opts in for unattended --yes runs.
   --yes                   Skip the pre-launch confirmation (for CI/non-interactive
                           use). The agent runs autonomously against --dir with
                           edits — and, depending on the agent, command execution —
@@ -57,6 +60,7 @@ function main(): void {
         agent: { type: 'string' },
         integrations: { type: 'string' },
         'print-prompt': { type: 'boolean', default: false },
+        sightmap: { type: 'boolean', default: false },
         yes: { type: 'boolean', default: false },
         mock: { type: 'boolean', default: false },
         'no-telemetry': { type: 'boolean', default: false },
@@ -106,6 +110,7 @@ function main(): void {
       .map((s) => s.trim())
       .filter(Boolean),
     printPrompt: values['print-prompt'] ?? false,
+    sightmap: values.sightmap ?? false,
     yes: values.yes ?? false,
     mock: values.mock ?? false,
     // Telemetry is on by default; both the explicit --no-telemetry flag and the

--- a/src/config.ts
+++ b/src/config.ts
@@ -228,5 +228,8 @@ export interface WizardOptions {
   printPrompt: boolean;
   /** Skip the pre-launch confirmation (non-interactive/CI use). */
   yes: boolean;
+  /** Opt into building a sightmap corpus under --yes. Interactive runs are
+   * always offered it; this only matters for unattended CI runs. */
+  sightmap: boolean;
   debug: boolean;
 }

--- a/src/prompt/sightmap.ts
+++ b/src/prompt/sightmap.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import { packageRootPath } from '../paths.js';
+import type { PromptMode } from './build.js';
+
+export interface BuildSightmapPromptInput {
+  mode: PromptMode;
+  /** Dev-server URL for the live-coverage pass, or undefined to seed from code only. */
+  appUrl?: string;
+}
+
+const HEADLESS_MODE_SECTION = `## Mode: autonomous (headless)
+
+You are running non-interactively inside the Subtext setup CLI. The user cannot answer questions mid-run. Apply your best judgment, keep the corpus small and accurate rather than exhaustive, and record what you built (plus anything you'd have asked) in \`./sightmap-setup-report.md\`. Never block waiting for input.`;
+
+const INTERACTIVE_MODE_SECTION = `## Mode: interactive
+
+Work through the steps with the user in this conversation. Show them the components you intend to define before writing large batches, and let them steer which surfaces matter most.`;
+
+/** The live-coverage pass only appears when the user gave us a dev-server URL. */
+function liveSection(appUrl: string): string {
+  return `## Step 4: Deepen coverage against the running app
+
+A dev server is running at ${appUrl}. Use it to find components you couldn't see from the code alone.
+
+1. Start a browser session: \`sightmap browser start --url '${appUrl}'\`.
+2. For each meaningful route, take a coverage snapshot — \`sightmap snapshot --coverage --url '<route-url>'\` — and read which on-screen elements have no component mapped yet.
+3. Add sightmap components for the uncovered elements that a person would name, using \`sightmap sel-probe\` to confirm a selector matches before you commit it.
+4. Re-run \`sightmap validate\` and \`sightmap lint\` until clean.
+
+If the \`sightmap-browser\` skill is available, use it to drive this loop.`;
+}
+
+export function buildSightmapPrompt(input: BuildSightmapPromptInput): string {
+  const template = fs.readFileSync(packageRootPath('templates', 'sightmap-prompt.md'), 'utf8');
+  const headless = input.mode === 'headless';
+  const live = Boolean(input.appUrl);
+
+  const replacements: Record<string, string> = {
+    MODE_SECTION: headless ? HEADLESS_MODE_SECTION : INTERACTIVE_MODE_SECTION,
+    LIVE_SECTION: live ? liveSection(input.appUrl!) : '',
+    // The live pass is Step 4, so the report becomes Step 5 when it's present.
+    REPORT_STEP: live ? '5' : '4',
+    REPORT_VERB: headless ? 'Record' : 'Tell the user',
+    REPORT_LOCATION: headless
+      ? 'Put this in `./sightmap-setup-report.md`.'
+      : '',
+  };
+
+  let prompt = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    prompt = prompt.replaceAll(`{{${key}}}`, value);
+  }
+  return prompt.replace(/\n{3,}/g, '\n\n').trim() + '\n';
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -12,6 +12,7 @@ import { guidePluginSetup } from './plugin.js';
 import { offerPluginSetup } from './pluginSetup.js';
 import { buildInstallPrompt, type PromptTelemetry } from './prompt/build.js';
 import { offerPromptReview } from './promptReview.js';
+import { offerSightmapSetup } from './sightmap.js';
 import { fetchCaptureSnippet } from './snippet.js';
 import { Telemetry } from './telemetry.js';
 
@@ -195,6 +196,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       await offerPluginSetup(MANUAL_CHOICE, auth.region, options, (event, properties) =>
         telemetry.note(event, properties),
       );
+      await offerSightmapSetup(MANUAL_CHOICE, options, (event, properties) =>
+        telemetry.note(event, properties),
+      );
       await showDemoGuide({
         agentName: 'your coding agent',
         installPending: true,
@@ -274,6 +278,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
 
     if (result.mode === 'handoff') {
       p.note(result.followUp?.join('\n') ?? '', 'Next steps');
+      await offerSightmapSetup(chosen, options, (event, properties) =>
+        telemetry.note(event, properties),
+      );
       await showDemoGuide({
         agentName: chosen.definition.name,
         installPending: true,
@@ -286,6 +293,9 @@ export async function runWizard(options: WizardOptions): Promise<number> {
       // Terminal run finished — wire Subtext into the harness that ran it
       // (packaged plugin where one exists, raw MCP entry otherwise).
       await offerPluginSetup(chosen, auth.region, options, (event, properties) =>
+        telemetry.note(event, properties),
+      );
+      await offerSightmapSetup(chosen, options, (event, properties) =>
         telemetry.note(event, properties),
       );
       await showDemoGuide({

--- a/src/sightmap.ts
+++ b/src/sightmap.ts
@@ -1,0 +1,237 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { runTerminalAgent, which } from './agents/helpers.js';
+import { MANUAL_CHOICE } from './agents/index.js';
+import type { DetectedAgent } from './agents/types.js';
+import type { WizardOptions } from './config.js';
+import { buildSightmapPrompt } from './prompt/sightmap.js';
+
+/**
+ * Post-install: offer to build a `.sightmap/` component corpus so future
+ * Subtext session reviews come back annotated with semantic component names
+ * instead of raw CSS selectors. Independent of the capture snippet — the
+ * corpus maps the app's UI regardless of capture — but it only pays off in
+ * review, so onboarding is the natural place to front-load it.
+ *
+ * Delivery follows the sightmap quickstart: the standalone `@sightmap/sightmap`
+ * CLI provides the binary that both the wizard and the agent's authoring skill
+ * shell out to (`validate`, `lint`, `snapshot`, `browser start`), so it must be
+ * on PATH before any authoring happens. The corpus itself is authored by the
+ * user's own coding agent — same handoff model as the main install — because
+ * the CLI has no "seed" command; writing the YAML is an agent task guided by
+ * the `sightmap-authoring` skill (or the docs, as a fallback).
+ *
+ * Never throws: the install already succeeded, so sightmap trouble is reported
+ * and the wizard still finishes cleanly.
+ */
+
+const SIGHTMAP_PACKAGE = '@sightmap/sightmap';
+const SIGHTMAP_DOCS = 'https://docs.sightmap.org/start/quickstart';
+
+const WHY_SIGHTMAP =
+  'A sightmap maps your UI components so Subtext session reviews name them ("add-to-cart button") instead of showing raw selectors.';
+
+type OnEvent = (event: string, properties?: Record<string, unknown>) => void;
+
+/** True when we can drive the authoring run ourselves in this terminal. */
+function isAutoDrivable(
+  chosen: DetectedAgent | typeof MANUAL_CHOICE,
+): chosen is DetectedAgent {
+  return (
+    chosen !== MANUAL_CHOICE &&
+    chosen.definition.kind === 'terminal' &&
+    Boolean(chosen.binaryPath)
+  );
+}
+
+/** The two commands, shown in instructions and mock output. */
+function provisionCommands(): string[] {
+  return [`npm install -g ${SIGHTMAP_PACKAGE}`, 'sightmap skills install'];
+}
+
+/**
+ * Put the sightmap CLI (and its authoring skill) on PATH, per the quickstart.
+ * A global install is deliberate: the agent's later skill calls invoke a bare
+ * `sightmap`, so the binary has to be resolvable outside this process — an
+ * npx-only approach wouldn't survive the handoff. Returns whether `sightmap`
+ * ended up runnable; failures fall back to instructions, never abort.
+ */
+async function provisionCli(cwd: string): Promise<boolean> {
+  const existing = await which('sightmap');
+  if (existing) {
+    p.log.info(pc.dim('sightmap CLI already installed — skipping install.'));
+  } else {
+    const npm = await which('npm');
+    if (!npm) {
+      p.log.warn('Could not find npm on PATH to install the sightmap CLI.');
+      return false;
+    }
+    p.log.step(`Installing the sightmap CLI (${SIGHTMAP_PACKAGE})…`);
+    let installExit: number;
+    try {
+      installExit = await runTerminalAgent({
+        binaryPath: npm,
+        args: ['install', '-g', SIGHTMAP_PACKAGE],
+        cwd,
+        stdout: 'inherit',
+      });
+    } catch {
+      installExit = 1;
+    }
+    if (installExit !== 0 || !(await which('sightmap'))) {
+      p.log.warn(
+        'sightmap CLI install failed — you may need elevated permissions ' +
+          `(e.g. sudo npm install -g ${SIGHTMAP_PACKAGE}).`,
+      );
+      return false;
+    }
+  }
+
+  // Skills are best-effort: the authoring prompt falls back to the docs when
+  // the skill isn't present, so a failed `skills install` doesn't sink setup.
+  const sightmap = await which('sightmap');
+  if (sightmap) {
+    try {
+      await runTerminalAgent({
+        binaryPath: sightmap,
+        args: ['skills', 'install'],
+        cwd,
+        stdout: 'inherit',
+      });
+    } catch {
+      p.log.info(pc.dim('sightmap skills install skipped — the agent will use the docs instead.'));
+    }
+  }
+  return true;
+}
+
+/** Interactive-only: an optional dev-server URL enables the live-coverage pass. */
+async function askAppUrl(options: WizardOptions): Promise<string | undefined> {
+  if (options.yes) return undefined; // CI: never prompt; static seed only.
+  const answer = await p.text({
+    message:
+      'Local dev server running? Paste its URL to deepen coverage against the live app (blank = seed from code only):',
+    placeholder: 'http://localhost:3000',
+  });
+  if (p.isCancel(answer)) return undefined;
+  const url = String(answer ?? '').trim();
+  if (!url) return undefined;
+  if (!/^https?:\/\//i.test(url)) {
+    p.log.warn('That does not look like an http(s) URL — seeding from code only.');
+    return undefined;
+  }
+  return url;
+}
+
+/** Manual / GUI-app path: we can't drive a second run, so hand over the recipe. */
+function showInstructions(onEvent: OnEvent): void {
+  p.note(
+    [
+      WHY_SIGHTMAP,
+      '',
+      'Install the CLI and its authoring skill:',
+      ...provisionCommands().map((c) => `  ${c}`),
+      '',
+      'Then, in your coding agent at this project, ask it to:',
+      '  "Use the sightmap-authoring skill to seed a .sightmap/ corpus from',
+      '   this codebase, then run sightmap validate and sightmap lint."',
+      '',
+      `Reference: ${SIGHTMAP_DOCS}`,
+    ].join('\n'),
+    'Add semantic component names',
+  );
+  onEvent('sightmap_instructions_shown');
+}
+
+export async function offerSightmapSetup(
+  chosen: DetectedAgent | typeof MANUAL_CHOICE,
+  options: WizardOptions,
+  onEvent: OnEvent,
+): Promise<void> {
+  // In CI (--yes) sightmap is off unless explicitly asked for: it installs a
+  // global and, for the live pass, wants a running app — not something to
+  // spring on an unattended run.
+  if (options.yes && !options.sightmap) return;
+
+  onEvent('sightmap_offered', {
+    agent: chosen === MANUAL_CHOICE ? MANUAL_CHOICE : chosen.definition.id,
+  });
+
+  // Confirm gate, matching the wizard's other post-install offers. --yes with
+  // --sightmap is the standing authorization; otherwise ask.
+  if (!options.yes) {
+    const yes = await p.confirm({
+      message: `Build a component sightmap so reviews name your UI? ${pc.dim(
+        `(installs ${SIGHTMAP_PACKAGE})`,
+      )}`,
+    });
+    if (p.isCancel(yes) || !yes) {
+      onEvent('sightmap_declined');
+      return;
+    }
+  }
+
+  if (!isAutoDrivable(chosen)) {
+    // Manual prompt, or a GUI app we can't relaunch headlessly — hand over the
+    // commands and the one-line ask instead of driving it.
+    showInstructions(onEvent);
+    return;
+  }
+
+  // Gather the live-pass URL before building the prompt so the corpus is
+  // authored in a single agent run rather than two.
+  const appUrl = await askAppUrl(options);
+
+  if (options.mock) {
+    p.log.info(
+      pc.dim(
+        `Mock mode: would run\n  ${provisionCommands().join('\n  ')}\n` +
+          `then hand ${chosen.definition.name} a sightmap authoring prompt` +
+          (appUrl ? ` (with a live pass against ${appUrl}).` : '.'),
+      ),
+    );
+    onEvent('sightmap_authored', { method: 'mock', live: Boolean(appUrl) });
+    return;
+  }
+
+  const provisioned = await provisionCli(options.dir);
+  onEvent('sightmap_provisioned', { ok: provisioned });
+  if (!provisioned) {
+    showInstructions(onEvent);
+    return;
+  }
+
+  const prompt = buildSightmapPrompt({ mode: 'headless', appUrl });
+  p.log.step(`Authoring the sightmap with ${chosen.definition.name}…`);
+  let result;
+  try {
+    result = await chosen.definition.launch({
+      prompt,
+      cwd: options.dir,
+      binaryPath: chosen.binaryPath,
+      debug: options.debug,
+      onEvent,
+    });
+  } catch (error) {
+    p.log.warn(
+      `Sightmap authoring didn't run: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    onEvent('sightmap_authored', { method: 'launch', outcome: 'error', live: Boolean(appUrl) });
+    return;
+  }
+
+  const ok = result.mode === 'ran' && result.exitCode === 0;
+  onEvent('sightmap_authored', {
+    method: 'launch',
+    outcome: ok ? 'success' : 'partial',
+    exit_code: result.exitCode ?? null,
+    live: Boolean(appUrl),
+  });
+  if (ok) {
+    p.log.success('Sightmap corpus authored in .sightmap/ — reviews will use it once uploaded.');
+  } else {
+    p.log.warn(
+      'Sightmap authoring finished without a clean exit — check .sightmap/ and sightmap-setup-report.md.',
+    );
+  }
+}

--- a/templates/sightmap-prompt.md
+++ b/templates/sightmap-prompt.md
@@ -1,0 +1,31 @@
+Build a sightmap component corpus for this app so Subtext session reviews come back with semantic component names instead of raw CSS selectors.
+
+{{MODE_SECTION}}
+
+## Reference
+
+A sightmap is a `.sightmap/` corpus: a `components.yaml` of global components plus per-view YAML under `.sightmap/views/`, each mapping a stable component id to the selectors that identify it in the DOM. Subtext reads this corpus when it annotates session snapshots.
+
+If a `sightmap-authoring` skill is available in this environment, use it — it is the source of truth for the corpus format and the authoring workflow. If it isn't, fetch https://docs.sightmap.org/start/quickstart and use the docs as your reference. Either way, the `sightmap` CLI (`validate`, `lint`, `snapshot`) is already installed and on PATH.
+
+## Step 1: Check the tooling
+
+Run `sightmap --version` to confirm the CLI is available. If the command is missing, install it with `npm install -g @sightmap/sightmap` and try again. If it still can't be installed, stop and report that the CLI is unavailable — the rest of this task depends on it.
+
+## Step 2: Seed the corpus from the codebase
+
+Do a read-only pass over the app's UI code — routes/pages, shared layout, and the reusable components that make up the meaningful surfaces (navigation, forms, product/list items, dialogs, account and settings screens). For each one that a person would name when describing the page ("the add-to-cart button", "the search box"), define a sightmap component with a stable id and the selector that identifies it.
+
+- Prefer durable selectors: `data-testid`, `data-*` hooks, roles, and stable ids over brittle class chains.
+- Put app-wide components (header, nav, footer, global search) in `components.yaml`; put view-specific ones in the matching file under `.sightmap/views/`.
+- Name views after the routes they cover. Don't invent components for markup that doesn't exist — only map what's really in the code.
+
+## Step 3: Validate and lint
+
+Run `sightmap validate` and `sightmap lint`. Fix whatever they flag — malformed YAML, duplicate ids, selectors that don't parse — and re-run until both pass clean.
+
+{{LIVE_SECTION}}
+
+## Step {{REPORT_STEP}}: Report
+
+{{REPORT_VERB}} what you built: the number of components and views authored, which surfaces are covered, and any notable gaps you couldn't map from the code (dynamic routes, third-party embeds, anything that needs a running app to see). {{REPORT_LOCATION}}


### PR DESCRIPTION
## What

Adds an optional **sightmap** step to the wizard: after the capture snippet install, offer to build a `.sightmap/` component corpus so future Subtext session reviews name the app's UI components ("add-to-cart button") instead of showing raw CSS selectors.

Follows the same handoff model as the main install — no bundled agent, the corpus is authored by the user's own coding agent — and mirrors the existing `offerPluginSetup` post-install pattern.

## Design choices

- **Placement:** a post-install offer (`offerSightmapSetup`), keeping the core snippet prompt lean and treating sightmap as a clearly-optional upsell.
- **Build mode:** static seed-from-code by default; an optional live-coverage pass against a running dev server when the user pastes a URL.
- **Delivery:** the standalone `@sightmap/sightmap` CLI (`npm i -g` + `sightmap skills install`), per the [quickstart](https://docs.sightmap.org/start/quickstart). The global install is deliberate — the agent's later skill calls invoke a bare `sightmap`, so the binary has to be resolvable outside the wizard process.

## Changes

- `src/sightmap.ts` — `offerSightmapSetup()`: confirm → optional dev-server URL → provision CLI → hand the chosen terminal agent a focused authoring prompt. Manual/GUI paths get an instructions note instead of a second launch. Never throws; mock mode prints "would run…".
- `src/prompt/sightmap.ts` + `templates/sightmap-prompt.md` — the authoring prompt. Live pass renders only when a URL is given; uses the `sightmap-authoring`/`sightmap-browser` skills when present, falls back to the docs.
- `src/run.ts` — wired into all three exit branches (terminal success, manual, GUI handoff), after `offerPluginSetup`, before the demo guide.
- `--sightmap` flag (`bin.ts`/`config.ts`) — sightmap is offered interactively by default; this opts in for unattended `--yes` runs (off otherwise, since it installs a global and the live pass wants a running app).
- README + changeset (minor).

## Notes / worth a look

- Under the standalone-CLI delivery, the corpus is still authored by the coding agent (the CLI has no `seed` command), so the terminal path fires a **second, confirm-gated agent run**. Heavier than a plugin-only path would be.
- Global `npm i -g` can need `sudo` on some setups — handled with a fallback instructions note rather than an abort.

## Testing

- `npm run typecheck` and `npm run build` clean.
- Both prompt variants (static / live) render correctly, including step renumbering.
- Manual/CI instructions path exercised end-to-end via the mock flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Optional flow runs another autonomous agent pass and may execute `npm install -g`, but it does not change core auth/snippet install and is skipped in `--yes` unless `--sightmap` is set.
> 
> **Overview**
> Adds an **optional post-install sightmap step** so the wizard can help seed a `.sightmap/` component corpus after Subtext capture setup, making session reviews use semantic UI names instead of raw selectors.
> 
> After the main install (manual clipboard, GUI handoff, or successful terminal run), `offerSightmapSetup` prompts interactively by default; **`--sightmap`** opts in when **`--yes`** is used so CI/unattended runs skip it unless requested. Terminal agents get a **second agent run**: global `@sightmap/sightmap` install (+ optional `sightmap skills install`), an optional dev-server URL for a live-coverage pass in the prompt, and a templated authoring prompt (`buildSightmapPrompt` / `sightmap-prompt.md`). Manual and non-drivable GUI paths show install instructions instead. Failures are non-fatal (instructions fallback, telemetry events).
> 
> README and CLI help document the new step and flag; changeset bumps **minor**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c0738db9bee93d154e46b7a08a726a21872fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->